### PR TITLE
feat(platform): add cross-platform foundation with Ubuntu/macOS gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Version](https://img.shields.io/badge/version-v0.1.1-green)](https://github.com/oscarsixsecllc/sarge/releases)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
-[![Platform](https://img.shields.io/badge/platform-Ubuntu%2022.04%20%7C%2024.04-orange)](docs/quickstart.md)
+[![Platform](https://img.shields.io/badge/platform-Ubuntu%20%7C%20macOS-orange)](docs/quickstart.md)
 
 Sarge is an open source NIST 800-53 Rev 5 hardening standard, gap analysis tool, and drift detection system designed exclusively for [OpenClaw](https://openclaw.ai) deployments.
 
@@ -61,7 +61,9 @@ Full docs: [docs/quickstart.md](docs/quickstart.md)
 | System & Information Integrity | SI | 5 | Partial |
 | **Total** | | **47** | |
 
-**Baseline:** NIST SP 800-53 Rev 5 | **OS:** Ubuntu 22.04 / 24.04 LTS (x86_64, arm64)
+**Baseline:** NIST SP 800-53 Rev 5 | **Platforms:** Ubuntu 22.04 / 24.04 LTS (full); macOS (rolling out across PRs)
+
+> **Platform support status:** Full coverage on Ubuntu 22.04 / 24.04 LTS today. macOS support is being added one module at a time so each platform's 800-53 mapping can be reviewed independently. On macOS, `scripts/install.sh` currently applies file-permission hardening only; gap analysis and drift detection refuse cleanly until their macOS-aware probes ship. Roadmap is tracked in [GitHub issues](https://github.com/oscarsixsecllc/sarge/issues).
 
 > **Why SC and SI are partial:**
 > 
@@ -83,6 +85,8 @@ On a clean Ubuntu 24.04 LTS system with Sarge hardening applied:
 | ⏭️ SKIP | 2 |
 
 The 4 remaining FAILs (auditd daemon, pam_faillock, fail2ban) require systemd and will pass on a standard Linux VM.
+
+> **macOS validation pending.** The numbers above are Ubuntu 24.04 only. macOS gap-analysis and hardening modules are landing PR-by-PR; each module will publish its own validated PASS/WARN/FAIL counts as it ships.
 
 ---
 

--- a/assessment/assess.sh
+++ b/assessment/assess.sh
@@ -6,6 +6,20 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/platform.sh
+source "${REPO_ROOT}/lib/platform.sh"
+sarge_require_supported_os
+
+# Assessment checks are currently Ubuntu-only. macOS-aware probes ship in the
+# next PR — until then, refuse on macOS rather than emit garbage results.
+if [[ "$SARGE_OS" != "ubuntu" ]]; then
+  echo "[Sarge] Gap analysis on ${SARGE_OS_DESCRIPTION} is not yet implemented." >&2
+  echo "[Sarge] Track the rollout: https://github.com/oscarsixsecllc/sarge/issues" >&2
+  exit 2
+fi
+
 REPORT_DIR="${SARGE_REPORT_DIR:-$HOME/.sarge/reports}"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 REPORT_BASE="${REPORT_DIR}/sarge-report-${TIMESTAMP}"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,9 @@
 # Sarge Quickstart
 
 ## Prerequisites
-- Ubuntu 22.04 or 24.04 LTS (x86_64 or arm64)
+- One of:
+  - Ubuntu 22.04 or 24.04 LTS (x86_64 or arm64) — full coverage
+  - macOS — file-permission hardening today; assess / drift / additional hardening modules rolling out across PRs
 - OpenClaw installed
 - Git
 

--- a/drift/compare.sh
+++ b/drift/compare.sh
@@ -2,6 +2,14 @@
 # compare.sh — Compare Current State vs Sarge Snapshot — NIST 800-53 CM-2
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/platform.sh
+source "${REPO_ROOT}/lib/platform.sh"
+sarge_require_supported_os
+sarge_require_os ubuntu
+
 SNAPSHOT_DIR="${SARGE_SNAPSHOT_DIR:-$HOME/.sarge/snapshots}"
 LATEST="$SNAPSHOT_DIR/latest.json"
 

--- a/drift/drift-cron.sh
+++ b/drift/drift-cron.sh
@@ -4,6 +4,11 @@
 set -euo pipefail
 
 SARGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+
+# shellcheck source=../lib/platform.sh
+source "${SARGE_DIR}/lib/platform.sh"
+sarge_require_supported_os
+sarge_require_os ubuntu
 LOG_FILE="${SARGE_LOG_FILE:-$HOME/.sarge/drift.log}"
 mkdir -p "$(dirname "$LOG_FILE")"
 

--- a/drift/snapshot.sh
+++ b/drift/snapshot.sh
@@ -2,6 +2,14 @@
 # snapshot.sh — Capture Sarge Baseline Snapshot — NIST 800-53 CM-2
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/platform.sh
+source "${REPO_ROOT}/lib/platform.sh"
+sarge_require_supported_os
+sarge_require_os ubuntu
+
 SNAPSHOT_DIR="${SARGE_SNAPSHOT_DIR:-$HOME/.sarge/snapshots}"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 SNAPSHOT_FILE="$SNAPSHOT_DIR/snapshot-${TIMESTAMP}.json"

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# lib/platform.sh — Sarge platform detection and capability gates
+# Sourced by assessment, hardening, and drift scripts.
+#
+# Exports:
+#   SARGE_OS              "ubuntu" | "macos" | "unsupported"
+#   SARGE_OS_VERSION      version string (e.g. "24.04", "14.5")
+#   SARGE_OS_DESCRIPTION  human-readable identifier (e.g. "Ubuntu 24.04 LTS")
+#
+# Provides:
+#   sarge_require_supported_os    refuse to run on platforms outside the support matrix
+#   sarge_require_os <os...>      refuse to run if SARGE_OS is not in the allowed list
+#
+# Idempotent: safe to source multiple times within a single shell.
+
+[[ -n "${_SARGE_PLATFORM_LOADED:-}" ]] && return 0
+_SARGE_PLATFORM_LOADED=1
+
+_sarge_uname_s=$(uname -s)
+case "$_sarge_uname_s" in
+  Linux)
+    if [[ -r /etc/os-release ]]; then
+      # shellcheck disable=SC1091
+      . /etc/os-release
+      if [[ "${ID:-}" == "ubuntu" ]]; then
+        SARGE_OS="ubuntu"
+        SARGE_OS_VERSION="${VERSION_ID:-unknown}"
+        SARGE_OS_DESCRIPTION="${PRETTY_NAME:-Ubuntu $SARGE_OS_VERSION}"
+      else
+        SARGE_OS="unsupported"
+        SARGE_OS_VERSION="${VERSION_ID:-unknown}"
+        SARGE_OS_DESCRIPTION="${PRETTY_NAME:-Linux $SARGE_OS_VERSION}"
+      fi
+    else
+      SARGE_OS="unsupported"
+      SARGE_OS_VERSION="unknown"
+      SARGE_OS_DESCRIPTION="Linux (no /etc/os-release)"
+    fi
+    ;;
+  Darwin)
+    SARGE_OS="macos"
+    SARGE_OS_VERSION=$(sw_vers -productVersion 2>/dev/null || echo "unknown")
+    SARGE_OS_DESCRIPTION="macOS ${SARGE_OS_VERSION}"
+    ;;
+  *)
+    SARGE_OS="unsupported"
+    SARGE_OS_VERSION="unknown"
+    SARGE_OS_DESCRIPTION="$_sarge_uname_s"
+    ;;
+esac
+unset _sarge_uname_s
+
+export SARGE_OS SARGE_OS_VERSION SARGE_OS_DESCRIPTION
+
+# Support matrix — keep in sync with README control coverage table
+_sarge_is_supported_version() {
+  case "$SARGE_OS" in
+    ubuntu)
+      case "$SARGE_OS_VERSION" in
+        22.04|24.04) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    macos)
+      # Any macOS version. Apple's release cadence and year-aligned naming
+      # (Sonoma 14, Sequoia 15, Tahoe 26, ...) make a tight allowlist brittle,
+      # and OpenClaw is a developer-facing surface where we want to meet users
+      # on whatever Mac they have. Tighten only if a specific version proves
+      # incompatible.
+      [[ -n "$SARGE_OS_VERSION" && "$SARGE_OS_VERSION" != "unknown" ]] && return 0
+      return 1
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+sarge_require_supported_os() {
+  if [[ "$SARGE_OS" == "unsupported" ]] || ! _sarge_is_supported_version; then
+    echo "[Sarge] Unsupported platform: ${SARGE_OS_DESCRIPTION}" >&2
+    echo "[Sarge] Sarge supports:" >&2
+    echo "  - Ubuntu 22.04 / 24.04 LTS  (full coverage)" >&2
+    echo "  - macOS                     (in progress — see roadmap)" >&2
+    echo "[Sarge] Roadmap: https://github.com/oscarsixsecllc/sarge/issues" >&2
+    exit 2
+  fi
+}
+
+# Gate a script to a specific OS list. Exits 0 (clean skip) when not applicable,
+# so platform-specific modules don't break a multi-module install on other OSes.
+sarge_require_os() {
+  local allowed
+  for allowed in "$@"; do
+    if [[ "$SARGE_OS" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  echo "[Sarge] Module not applicable on ${SARGE_OS} — requires: $*. Skipping." >&2
+  exit 0
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,9 +4,16 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../lib/platform.sh
+source "${REPO_ROOT}/lib/platform.sh"
+sarge_require_supported_os
+
 echo "============================================"
 echo " Sarge — NIST 800-53 Hardening"
 echo " Oscar Six Security LLC"
+echo " Platform: ${SARGE_OS_DESCRIPTION}"
 echo " This script applies all hardening modules."
 echo " Each module will prompt before making changes."
 echo "============================================"
@@ -14,7 +21,24 @@ echo ""
 read -r -p "Begin Sarge hardening sequence? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
-for script in harden-permissions harden-pam harden-auditd harden-fail2ban harden-ufw harden-systemd; do
+# Per-platform module list. Ubuntu retains full coverage; macOS ships only
+# the POSIX-clean modules that have been validated. Native macOS firewall,
+# auth, and audit modules will land in subsequent PRs.
+case "$SARGE_OS" in
+  ubuntu)
+    MODULES=(harden-permissions harden-pam harden-auditd harden-fail2ban harden-ufw harden-systemd)
+    ;;
+  macos)
+    MODULES=(harden-permissions)
+    echo ""
+    echo "[Sarge] macOS hardening is rolling out one module per PR."
+    echo "[Sarge] This release applies file-permission hardening only."
+    echo "[Sarge] Track the rollout: https://github.com/oscarsixsecllc/sarge/issues"
+    echo ""
+    ;;
+esac
+
+for script in "${MODULES[@]}"; do
   echo ""
   echo "--- $script ---"
   bash "$SCRIPT_DIR/${script}.sh"


### PR DESCRIPTION
Introduce lib/platform.sh with OS detection, a support-matrix gate, and two helpers (sarge_require_supported_os, sarge_require_os). Wire every entry point (install.sh, assess.sh, drift/snapshot.sh, drift/compare.sh, drift/drift-cron.sh) through the gates so unsupported hosts get a clear error instead of mid-script tool failures — e.g. the BSD/GNU sed mismatch that aborted hardening on macOS partway through harden-pam.sh.

install.sh now dispatches a per-platform module list:
  - ubuntu: full 6-module coverage (unchanged behavior)
  - macos:  harden-permissions only, with an explicit notice that additional modules will ship in subsequent PRs

assessment/assess.sh and drift/* refuse cleanly on non-Ubuntu (exit 2 for unsupported, exit 0 skip for "not applicable yet") so cron jobs and agent invocations don't error-spam.

Support matrix:
  - Ubuntu: strict — 22.04 / 24.04 LTS only (deployment promise)
  - macOS:  permissive — any version (developer surface; tighten later)

Public docs updated:
  - README platform badge: Ubuntu 22.04|24.04 -> Ubuntu | macOS
  - README "Platform support status" callout under Control Coverage
  - README "macOS validation pending" callout under Validated Results (Ubuntu PASS/WARN/FAIL counts intact)
  - docs/quickstart.md prereqs split per platform

Not in this PR (deliberate scope):
  - check-*.sh / harden-*.sh stay Ubuntu-bound; platform-aware probes and native macOS hardening modules land one-per-PR so each can be reviewed against its 800-53 control mapping in isolation
  - SKILL.md update deferred — TDD/BDD hook (tdd_bdd_gate.py) hard- blocks edits to that filename; needs hook config fix in follow-up

Verified locally on macOS 26.3.1:
  - install.sh    -> preflight passes, dispatches macOS module list
  - assess.sh     -> exit 2 with clear "not yet implemented" message
  - snapshot.sh   -> exit 0 clean skip via sarge_require_os ubuntu