### PR TITLE
chore(codeowners): add @keonik

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,11 @@
 # Changes to these paths require approval from Oscar Six Security maintainers
 
 # Core security content — requires maintainer review
-/scripts/          @oscarsixsecllc
-/assessment/       @oscarsixsecllc
-/baseline/         @oscarsixsecllc
-/drift/            @oscarsixsecllc
-/CHECKSUMS.sha256  @oscarsixsecllc
-/SKILL.md          @oscarsixsecllc
+/scripts/          @oscarsixsecllc @keonik
+/assessment/       @oscarsixsecllc @keonik
+/baseline/         @oscarsixsecllc @keonik
+/drift/            @oscarsixsecllc @keonik
+/CHECKSUMS.sha256  @oscarsixsecllc @keonik
+/SKILL.md          @oscarsixsecllc @keonik
 
 # Everything else — open for community contribution


### PR DESCRIPTION
Adds John Fay (`@keonik`) as a CODEOWNER on the protected paths alongside `@oscarsixsecllc`, so either maintainer can satisfy CODEOWNERS approval. John is a fully trusted core developer per Randy (2026-04-26).

Trivial doc change; no code paths affected.