### PR TITLE
fix(platform): address PR #3 review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ See [SECURITY.md](SECURITY.md) for vulnerability disclosure policy.
 
 ---
 
+## Script Exit Codes
+
+Sarge scripts use exit codes to signal *what they did*, not just *whether they succeeded*. The contract differs per script because each one serves a different role:
+
+| Script | Exit 0 | Exit 2 | Notes |
+|---|---|---|---|
+| `assessment/assess.sh` | Assessment ran; Markdown + JSON report generated | Platform not yet supported (no assessment performed) | **Exit 0 ≠ "your system passed."** Read the report for PASS/WARN/FAIL counts. |
+| `scripts/install.sh` | Hardening complete (or operator declined at any prompt) | Platform unsupported | Each module also prompts `[y/N]`; declining a module is exit 0 from that module. |
+| `scripts/harden-*.sh` | Module applied (or operator declined) | — | Run individually via `sudo bash scripts/harden-<name>.sh`. |
+| `drift/snapshot.sh` | Snapshot captured *or* clean skip on non-applicable platform | Platform unsupported | Designed to be safe in cron. |
+| `drift/compare.sh` | No drift detected *or* clean skip on non-applicable platform | Drift detected **or** platform unsupported | Read the script output to disambiguate. |
+| `drift/drift-cron.sh` | Success or clean skip | Platform unsupported | Wraps `compare.sh`; suitable for cron. |
+
+> **Why `assess.sh` exits 2 (not 0) on unsupported platforms.** Assessment is a *measurement* tool — exit 0 carries the meaning "I performed an assessment and produced a report." A silent exit 0 on an unsupported platform could be misread by CI pipelines as "this host has zero NIST gaps." Drift scripts use exit 0 for clean-skip because skipping is the desired behavior under cron; assess is interactive and CI-driven, where a loud failure is the correct signal.
+
+> **Verbose skip messages.** `sarge_require_os` (used by Linux-only modules to skip cleanly on macOS) is silent by default. Set `SARGE_VERBOSE=1` in the environment to see why a module skipped.
+
+---
+
 ## Repository Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -116,15 +116,15 @@ See [SECURITY.md](SECURITY.md) for vulnerability disclosure policy.
 
 ## Script Exit Codes
 
-Sarge scripts use exit codes to signal *what they did*, not just *whether they succeeded*. The contract differs per script because each one serves a different role:
+Sarge scripts use exit codes to signal *what they did*, not just *whether they succeeded*. The contract differs per script because each one serves a different role. Unless explicitly noted below, any non-`0` / non-`2` exit should be treated as an unexpected runtime or precondition error and investigated from the script output.
 
 | Script | Exit 0 | Exit 2 | Notes |
 |---|---|---|---|
 | `assessment/assess.sh` | Assessment ran; Markdown + JSON report generated | Platform not yet supported (no assessment performed) | **Exit 0 ≠ "your system passed."** Read the report for PASS/WARN/FAIL counts. |
-| `scripts/install.sh` | Hardening complete (or operator declined at any prompt) | Platform unsupported | Each module also prompts `[y/N]`; declining a module is exit 0 from that module. |
-| `scripts/harden-*.sh` | Module applied (or operator declined) | — | Run individually via `sudo bash scripts/harden-<name>.sh`. |
+| `scripts/install.sh` | Hardening complete (or operator declined at any prompt) | Platform unsupported | Each module also prompts `[y/N]`; declining a module is exit 0 from that module. Privilege requirements vary per module (see below). |
+| `scripts/harden-*.sh` | Module applied (or operator declined) | — | **Privilege requirements vary by module — check each script's header for the authoritative requirement.** `harden-permissions.sh` runs as the invoking user and uses `$HOME` (do **not** invoke with `sudo` directly, or `$HOME` will resolve to `/root` and the wrong workspace will be hardened). The other modules (`harden-pam`, `harden-auditd`, `harden-fail2ban`, `harden-ufw`, `harden-systemd`) write to `/etc/` and require `sudo`. |
 | `drift/snapshot.sh` | Snapshot captured *or* clean skip on non-applicable platform | Platform unsupported | Designed to be safe in cron. |
-| `drift/compare.sh` | No drift detected *or* clean skip on non-applicable platform | Drift detected **or** platform unsupported | Read the script output to disambiguate. |
+| `drift/compare.sh` | No drift detected *or* clean skip on non-applicable platform | Drift detected **or** platform unsupported (read script output to disambiguate) | Exits `1` when no snapshot exists (`No snapshot found. Run snapshot.sh first.`) — run `snapshot.sh` first. |
 | `drift/drift-cron.sh` | Success or clean skip | Platform unsupported | Wraps `compare.sh`; suitable for cron. |
 
 > **Why `assess.sh` exits 2 (not 0) on unsupported platforms.** Assessment is a *measurement* tool — exit 0 carries the meaning "I performed an assessment and produced a report." A silent exit 0 on an unsupported platform could be misread by CI pipelines as "this host has zero NIST gaps." Drift scripts use exit 0 for clean-skip because skipping is the desired behavior under cron; assess is interactive and CI-driven, where a loud failure is the correct signal.

--- a/assessment/assess.sh
+++ b/assessment/assess.sh
@@ -12,8 +12,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${REPO_ROOT}/lib/platform.sh"
 sarge_require_supported_os
 
-# Assessment checks are currently Ubuntu-only. macOS-aware probes ship in the
-# next PR — until then, refuse on macOS rather than emit garbage results.
+# Assessment checks are currently Ubuntu-only. macOS-aware probes ship in a
+# follow-up PR — until then, refuse on non-Ubuntu rather than emit garbage
+# results. Exit 2 is deliberate (not exit 0): assess is a measurement tool, so
+# a silent exit 0 could be misread by CI as "no NIST gaps found." See the
+# "Script Exit Codes" section in README.md for the full per-script contract.
 if [[ "$SARGE_OS" != "ubuntu" ]]; then
   echo "[Sarge] Gap analysis on ${SARGE_OS_DESCRIPTION} is not yet implemented." >&2
   echo "[Sarge] Track the rollout: https://github.com/oscarsixsecllc/sarge/issues" >&2

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -64,7 +64,7 @@ _sarge_is_supported_version() {
     macos)
       # Any macOS version. Apple's release cadence and year-aligned naming
       # (Sonoma 14, Sequoia 15, Tahoe 26, ...) make a tight allowlist brittle,
-      # and OpenClaw is a developer-facing surface where we want to meet users
+      # and Sarge is a developer-facing surface where we want to meet users
       # on whatever Mac they have. Tighten only if a specific version proves
       # incompatible.
       [[ -n "$SARGE_OS_VERSION" && "$SARGE_OS_VERSION" != "unknown" ]] && return 0
@@ -87,6 +87,9 @@ sarge_require_supported_os() {
 
 # Gate a script to a specific OS list. Exits 0 (clean skip) when not applicable,
 # so platform-specific modules don't break a multi-module install on other OSes.
+# The skip is silent by default — exit 0 means "intentional no-op" and we don't
+# want stderr noise in cron mail or agent transcripts. Set SARGE_VERBOSE=1 to
+# surface the skip message for debugging.
 sarge_require_os() {
   local allowed
   for allowed in "$@"; do
@@ -94,6 +97,8 @@ sarge_require_os() {
       return 0
     fi
   done
-  echo "[Sarge] Module not applicable on ${SARGE_OS} — requires: $*. Skipping." >&2
+  if [[ "${SARGE_VERBOSE:-0}" == "1" ]]; then
+    echo "[Sarge] Module not applicable on ${SARGE_OS} — requires: $*. Skipping." >&2
+  fi
   exit 0
 }


### PR DESCRIPTION
## Summary
Addresses the three unresolved Copilot review comments on #3:

- **Comment [3142960999](https://github.com/oscarsixsecllc/sarge/pull/3#discussion_r3142960999)** — `lib/platform.sh:67`: "OpenClaw" → "Sarge" in the macOS-matrix rationale comment. Copy-paste error.
- **Comment [3142961001](https://github.com/oscarsixsecllc/sarge/pull/3#discussion_r3142961001)** — `lib/platform.sh` `sarge_require_os`: skip is now silent by default. Set `SARGE_VERBOSE=1` to surface the skip message for debugging.
- **Comment [3142961007](https://github.com/oscarsixsecllc/sarge/pull/3#discussion_r3142961007)** — `assessment/assess.sh:20`: exit-code contract clarified, not changed. `assess.sh` keeps exit 2 on unsupported platforms because it's a measurement tool — a silent exit 0 could be misread by CI as "no NIST gaps found." Drift scripts use exit 0 because skip is the desired behavior under cron. Documented in a new "Script Exit Codes" section in the README and a cross-ref comment in `assess.sh`.

## Test plan
- [x] `drift/snapshot.sh` on macOS 26.3.1 → silent exit 0
- [x] `SARGE_VERBOSE=1 drift/snapshot.sh` on macOS 26.3.1 → message + exit 0
- [x] `assessment/assess.sh` on macOS 26.3.1 → exit 2 with clear message
- [ ] (Reviewer) Sanity-check that Ubuntu behavior is unchanged — only entry-script gating logic touched, no `check-*.sh` or `harden-*.sh` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)