### PR TITLE
fix(harden-permissions): resolve $SUDO_USER's home, not /root

### DIFF
--- a/scripts/harden-permissions.sh
+++ b/scripts/harden-permissions.sh
@@ -2,11 +2,26 @@
 # harden-permissions.sh — File/Directory Permissions — NIST 800-53 AC-3, SC-28
 set -euo pipefail
 
+# Resolve the invoking user's home directory. When this script is run under
+# sudo (e.g. via scripts/install.sh, or `sudo bash harden-permissions.sh`),
+# Ubuntu's default sudoers resets $HOME to /root — which would harden
+# /root/.openclaw instead of the operator's workspace. Detect $SUDO_USER and
+# use its home so the right directory gets locked down.
+if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+  TARGET_HOME=$(eval echo "~$SUDO_USER")
+  TARGET_USER="$SUDO_USER"
+else
+  TARGET_HOME="$HOME"
+  TARGET_USER=$(whoami)
+fi
+
 echo "[Sarge] Permissions Hardening — AC-3/SC-28"
+echo "  Target user: $TARGET_USER"
+echo "  Target home: $TARGET_HOME"
 read -r -p "Apply OpenClaw file permission hardening? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
-OC_DIR="$HOME/.openclaw"
+OC_DIR="$TARGET_HOME/.openclaw"
 if [[ -d "$OC_DIR" ]]; then
   chmod 700 "$OC_DIR"
   echo "  Set $OC_DIR → 700"

--- a/scripts/harden-permissions.sh
+++ b/scripts/harden-permissions.sh
@@ -7,9 +7,36 @@ set -euo pipefail
 # Ubuntu's default sudoers resets $HOME to /root — which would harden
 # /root/.openclaw instead of the operator's workspace. Detect $SUDO_USER and
 # use its home so the right directory gets locked down.
+resolve_home_for_user() {
+  local user="$1"
+  local resolved_home=""
+
+  # Only allow conventional account names before querying the OS database.
+  if [[ ! "$user" =~ ^[A-Za-z_][A-Za-z0-9_.-]*[$]?$ ]]; then
+    return 1
+  fi
+
+  if command -v getent >/dev/null 2>&1; then
+    resolved_home=$(getent passwd "$user" | cut -d: -f6)
+  elif command -v dscl >/dev/null 2>&1; then
+    resolved_home=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+  fi
+
+  if [[ -n "$resolved_home" && "$resolved_home" = /* ]]; then
+    printf '%s\n' "$resolved_home"
+    return 0
+  fi
+
+  return 1
+}
+
 if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
-  TARGET_HOME=$(eval echo "~$SUDO_USER")
-  TARGET_USER="$SUDO_USER"
+  if TARGET_HOME=$(resolve_home_for_user "$SUDO_USER"); then
+    TARGET_USER="$SUDO_USER"
+  else
+    TARGET_HOME="$HOME"
+    TARGET_USER=$(whoami)
+  fi
 else
   TARGET_HOME="$HOME"
   TARGET_USER=$(whoami)

--- a/scripts/harden-permissions.sh
+++ b/scripts/harden-permissions.sh
@@ -52,8 +52,10 @@ OC_DIR="$TARGET_HOME/.openclaw"
 if [[ -d "$OC_DIR" ]]; then
   chmod 700 "$OC_DIR"
   echo "  Set $OC_DIR → 700"
-  mkdir -p "$OC_DIR/secrets" && chmod 700 "$OC_DIR/secrets" && echo "  Set $OC_DIR/secrets → 700"
-  find "$OC_DIR/secrets" -type f -exec chmod 600 {} \; 2>/dev/null && echo "  Set secret files → 600"
+  if [[ -d "$OC_DIR/secrets" ]]; then
+    chmod 700 "$OC_DIR/secrets" && echo "  Set $OC_DIR/secrets → 700"
+    find "$OC_DIR/secrets" -type f -exec chmod 600 {} \; 2>/dev/null && echo "  Set secret files → 600"
+  fi
   [[ -f "$OC_DIR/config.json" ]] && chmod 600 "$OC_DIR/config.json" && echo "  Set config.json → 600"
 fi
 echo "[Sarge] Permissions hardening applied."


### PR DESCRIPTION
## Summary

`scripts/install.sh` runs as `sudo`, which on Ubuntu resets `\$HOME` to `/root`. `harden-permissions.sh` uses `\$HOME` to locate `~/.openclaw`, so the AC-3/SC-28 hardening was silently targeting `/root/.openclaw` (which doesn't exist) instead of the operator's workspace.

This was flagged during PR #5's review on the exit-code table — see [discussion_r3145025012](https://github.com/oscarsixsecllc/sarge/pull/5#discussion_r3145025012).

## Fix

Detect `\$SUDO_USER` at the top of the script and resolve that user's home via bash tilde expansion. Falls through to `\$HOME` when invoked directly (no sudo).

Also prints the target user/home before the `[y/N]` prompt so the operator can confirm before applying changes.

## Test plan

- [x] `SUDO_USER=jfay` → resolves to `/Users/jfay` (verified on macOS 26.3.1)
- [x] `SUDO_USER` unset → falls back to `\$HOME`
- [x] `bash -n` syntax check passes
- [ ] (Reviewer) Validate on a real Ubuntu host: `sudo ./scripts/install.sh` should now harden the invoking user's `~/.openclaw`, not `/root/.openclaw`

## Related

Closes the production-bug TODO from #5's review thread. PR #6's faillock parser tightening will follow once #6 lands (stacks on that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)