### PR TITLE
fix(platforms): tighten ubuntu_faillock_value parser

### DIFF
--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -138,12 +138,21 @@ ubuntu_pam_faillock_configured() {
 ubuntu_faillock_config_path() { echo "/etc/security/faillock.conf"; }
 
 # Read a value from faillock.conf (e.g. deny, unlock_time). Empty if unset.
-# Parser only handles the space-delimited form (`deny = 5`) — that's what
-# harden-pam.sh writes, so it's correct for Sarge-managed files. Tightening
-# the parser to also handle `deny=5` (no spaces) would be a behavior change
-# beyond this refactor's scope; tracked as a follow-up.
+# Handles both the space-delimited form (`deny = 5`) that harden-pam.sh writes
+# and the no-space form (`deny=5`) that operators may hand-edit. Comment lines
+# and bare-keyword settings (`silent`, `audit`) are skipped.
 ubuntu_faillock_value() {
-  grep "^$1" /etc/security/faillock.conf 2>/dev/null | awk '{ print $3 }'
+  awk -F= -v key="$1" '
+    /^[[:space:]]*#/ { next }
+    NF < 2          { next }
+    {
+      lhs = $1
+      rhs = $2
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", lhs)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", rhs)
+      if (lhs == key) { print rhs; exit }
+    }
+  ' /etc/security/faillock.conf 2>/dev/null
 }
 
 # First non-comment TMOUT line found in profile files. Empty if none.

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -152,7 +152,7 @@ ubuntu_faillock_value() {
       gsub(/^[[:space:]]+|[[:space:]]+$/, "", rhs)
       if (lhs == key) { print rhs; exit }
     }
-  ' /etc/security/faillock.conf 2>/dev/null
+  ' "$(ubuntu_faillock_config_path)" 2>/dev/null
 }
 
 # First non-comment TMOUT line found in profile files. Empty if none.


### PR DESCRIPTION
## Summary

Tightens `ubuntu_faillock_value` to handle the no-space form (`deny=5`) of faillock.conf in addition to the space-delimited form (`deny = 5`) that `harden-pam.sh` writes. Both are valid per `faillock(5)`; an operator hand-edit using the no-space form was previously silently misread.

Address from PR #6 review: [discussion_r3145014578](https://github.com/oscarsixsecllc/sarge/pull/6#discussion_r3145014578).

## Stacking

⚠️ **This PR is based on `refactor/platform-helpers-extraction` (PR #6), not `main`.** It cannot merge until #6 lands. Once #6 merges, GitHub will retarget this PR to `main` automatically (or it can be rebased).

## Test plan

Verified against a synthetic fixture on macOS 26.3.1:

| Input line | `ubuntu_faillock_value <key>` |
|---|---|
| `deny = 5` (space-delimited) | `5` |
| `unlock_time=1800` (no space) | `1800` |
| `fail_interval =  900` (extra whitespace) | `900` |
| `silent` (bare keyword, no `=`) | empty |
| absent key | empty |
| `# comment that mentions deny=99` | (correctly skipped) |

- [x] `bash -n` syntax check passes
- [x] All 5 fixture cases produce expected output
- [ ] (Reviewer) Validate on a real Ubuntu host that IA-2 PASS/WARN/FAIL counts are unchanged for default Sarge-hardened systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)