### PR TITLE
fix(platforms): tighten ubuntu_faillock_value parser (rebased from #8)

### DIFF
--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -138,12 +138,21 @@ ubuntu_pam_faillock_configured() {
 ubuntu_faillock_config_path() { echo "/etc/security/faillock.conf"; }
 
 # Read a value from faillock.conf (e.g. deny, unlock_time). Empty if unset.
-# Parser only handles the space-delimited form (`deny = 5`) — that's what
-# harden-pam.sh writes, so it's correct for Sarge-managed files. Tightening
-# the parser to also handle `deny=5` (no spaces) would be a behavior change
-# beyond this refactor's scope; tracked as a follow-up.
+# Parser handles both the space-delimited form (`deny = 5`) that harden-pam.sh
+# writes AND the no-space form (`deny=5`) that operators may use when hand-
+# editing. Skips comment lines and bare keywords (silent / audit).
 ubuntu_faillock_value() {
-  grep "^$1" /etc/security/faillock.conf 2>/dev/null | awk '{ print $3 }'
+  awk -F= -v key="$1" '
+    /^[[:space:]]*#/ { next }
+    NF < 2          { next }
+    {
+      lhs = $1
+      rhs = $2
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", lhs)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", rhs)
+      if (lhs == key) { print rhs; exit }
+    }
+  ' "$(ubuntu_faillock_config_path)" 2>/dev/null
 }
 
 # First non-comment TMOUT line found in profile files. Empty if none.


### PR DESCRIPTION
Replays @keonik's PR #8 onto post-#6 main. Original #8 was auto-closed when its base branch (\`refactor/platform-helpers-extraction\`) was deleted on the #6 merge — GitHub doesn't allow reopening with a missing base.

## Diff
Same single-file change as #8 (\`lib/platforms/ubuntu.sh\`):
- \`ubuntu_faillock_value\` rewritten to use \`awk -F=\` field parsing — handles both \`deny = 5\` (space-delimited, what \`harden-pam.sh\` writes) and \`deny=5\` (no-space, hand-edits)
- Skips comment lines and bare keywords (silent / audit)
- Uses the \`ubuntu_faillock_config_path\` helper instead of hardcoding \`/etc/security/faillock.conf\`

## Conflict resolved during cherry-pick
The pre-existing docstring above the function (added in #6) said *"tightening is a follow-up"* — now stale because we are landing the tightening. Updated to:

> Parser handles both the space-delimited form (\`deny = 5\`) that harden-pam.sh writes AND the no-space form (\`deny=5\`) that operators may use when hand-editing. Skips comment lines and bare keywords (silent / audit).

That's the only delta from #8's original diff. Authorship preserved (cherry-pick attributes John Fay).

## Acceptance criteria
Same fixture table as #8:
- \`deny = 5\` → \`5\`
- \`unlock_time=1800\` → \`1800\`
- \`fail_interval =  900\` → \`900\`
- \`silent\` (bare keyword) → empty
- absent key → empty
- \`# comment that mentions deny=99\` → correctly skipped

Refs: closes #8 (which was auto-closed by GH on base-branch deletion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)