### PR TITLE
refactor(drift): hoist drift-fields loops into shared dispatcher sinks

### DIFF
--- a/lib/platforms/_dispatch.sh
+++ b/lib/platforms/_dispatch.sh
@@ -56,3 +56,53 @@ platform() {
 platform_supports() {
   declare -F "${SARGE_OS}_$1" &>/dev/null
 }
+
+# ---------- Drift field plumbing (shared across platforms) ----------
+#
+# Each platform defines `_<os>_drift_fields` that emits one `key=value`
+# line per field it captures (see lib/platforms/<os>.sh). The two sinks
+# below consume that stream:
+#
+#   _<os>_drift_fields | sarge_emit_drift_snapshot_json
+#   _<os>_drift_fields | sarge_emit_drift_check_calls
+#
+# Living here (not per-platform) because the loops are byte-for-byte
+# identical across platforms — only the field set is platform-specific.
+# Pulling them up means adding a new platform's drift coverage is one
+# function (the field emitter), not three.
+
+# Emit a strict-JSON object body (no surrounding braces) from a stream
+# of `key=value` lines on stdin. Each line becomes `"key": "value",`
+# except the last, which omits the trailing comma. Skips blank lines so
+# field emitters can use empty echos as visual separators if desired.
+sarge_emit_drift_snapshot_json() {
+  local lines=() pair k v
+  while IFS= read -r pair; do
+    [[ -z "$pair" ]] && continue
+    k="${pair%%=*}"
+    v="${pair#*=}"
+    lines+=("    \"$k\": \"$v\"")
+  done
+  local n=${#lines[@]} i=0
+  while [[ $i -lt $n ]]; do
+    if [[ $i -lt $((n - 1)) ]]; then
+      printf '%s,\n' "${lines[$i]}"
+    else
+      printf '%s\n' "${lines[$i]}"
+    fi
+    i=$((i + 1))
+  done
+}
+
+# For each `key=value` line on stdin, invoke `check <key> <value>`. The
+# `check` function must already be defined in the caller's scope (see
+# drift/compare.sh). Unchanged from the per-platform loop it replaces.
+sarge_emit_drift_check_calls() {
+  local pair k v
+  while IFS= read -r pair; do
+    [[ -z "$pair" ]] && continue
+    k="${pair%%=*}"
+    v="${pair#*=}"
+    check "$k" "$v"
+  done
+}

--- a/lib/platforms/_dispatch.sh
+++ b/lib/platforms/_dispatch.sh
@@ -61,10 +61,20 @@ platform_supports() {
 #
 # Each platform defines `_<os>_drift_fields` that emits one `key=value`
 # line per field it captures (see lib/platforms/<os>.sh). The two sinks
-# below consume that stream:
+# below consume that stream — but the calling convention is asymmetric:
 #
+#   # snapshot: pipe is fine (sink writes stdout only, no shared state)
 #   _<os>_drift_fields | sarge_emit_drift_snapshot_json
-#   _<os>_drift_fields | sarge_emit_drift_check_calls
+#
+#   # check: MUST use process substitution, NOT a pipe
+#   sarge_emit_drift_check_calls < <(_<os>_drift_fields)
+#
+# Why: sarge_emit_drift_check_calls invokes `check`, which is defined in
+# drift/compare.sh and mutates a parent-shell `DRIFT` counter. In bash,
+# pipeline elements run in subshells by default, so a pipe here would
+# drop every DRIFT increment — compare.sh would print `[DRIFT] …` lines
+# but still exit 0 with "No drift detected." Process substitution keeps
+# the while-loop in the caller's shell, preserving the mutation.
 #
 # Living here (not per-platform) because the loops are byte-for-byte
 # identical across platforms — only the field set is platform-specific.

--- a/lib/platforms/macos.sh
+++ b/lib/platforms/macos.sh
@@ -245,5 +245,11 @@ _macos_drift_fields() {
 # lib/platforms/_dispatch.sh (sarge_emit_drift_snapshot_json /
 # sarge_emit_drift_check_calls) — these wrappers exist only to satisfy
 # the `platform drift_*_fields` dispatch contract.
+#
+# The snapshot wrapper uses a pipe; the check wrapper uses process
+# substitution. They look symmetric but they're not — see the rationale
+# block on sarge_emit_drift_check_calls in _dispatch.sh. tl;dr: `check`
+# mutates a DRIFT counter in compare.sh's scope, and a pipe would run
+# the sink in a subshell that drops the mutation.
 macos_drift_snapshot_fields() { _macos_drift_fields | sarge_emit_drift_snapshot_json; }
 macos_drift_check_fields()    { sarge_emit_drift_check_calls < <(_macos_drift_fields); }

--- a/lib/platforms/macos.sh
+++ b/lib/platforms/macos.sh
@@ -246,4 +246,4 @@ _macos_drift_fields() {
 # sarge_emit_drift_check_calls) — these wrappers exist only to satisfy
 # the `platform drift_*_fields` dispatch contract.
 macos_drift_snapshot_fields() { _macos_drift_fields | sarge_emit_drift_snapshot_json; }
-macos_drift_check_fields()    { _macos_drift_fields | sarge_emit_drift_check_calls; }
+macos_drift_check_fields()    { sarge_emit_drift_check_calls < <(_macos_drift_fields); }

--- a/lib/platforms/macos.sh
+++ b/lib/platforms/macos.sh
@@ -241,37 +241,9 @@ _macos_drift_fields() {
   echo "system_integrity_protection=${sip:-unknown}"
 }
 
-# Emit the JSON object body (no surrounding braces) for the macOS
-# snapshot. Each line is `"key": "value",` except the last has no
-# trailing comma.
-macos_drift_snapshot_fields() {
-  local lines=()
-  local pair k v
-  while IFS= read -r pair; do
-    [[ -z "$pair" ]] && continue
-    k="${pair%%=*}"
-    v="${pair#*=}"
-    lines+=("    \"$k\": \"$v\"")
-  done < <(_macos_drift_fields)
-  local n=${#lines[@]} i=0
-  while [[ $i -lt $n ]]; do
-    if [[ $i -lt $((n - 1)) ]]; then
-      printf '%s,\n' "${lines[$i]}"
-    else
-      printf '%s\n' "${lines[$i]}"
-    fi
-    i=$((i + 1))
-  done
-}
-
-# Run the platform-specific drift comparisons. Caller (compare.sh) must
-# have defined `check <field> <current-value>` in scope before invoking.
-macos_drift_check_fields() {
-  local pair k v
-  while IFS= read -r pair; do
-    [[ -z "$pair" ]] && continue
-    k="${pair%%=*}"
-    v="${pair#*=}"
-    check "$k" "$v"
-  done < <(_macos_drift_fields)
-}
+# Snapshot + compare dispatch entry points. The actual loops live in
+# lib/platforms/_dispatch.sh (sarge_emit_drift_snapshot_json /
+# sarge_emit_drift_check_calls) — these wrappers exist only to satisfy
+# the `platform drift_*_fields` dispatch contract.
+macos_drift_snapshot_fields() { _macos_drift_fields | sarge_emit_drift_snapshot_json; }
+macos_drift_check_fields()    { _macos_drift_fields | sarge_emit_drift_check_calls; }

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -236,4 +236,4 @@ _ubuntu_drift_fields() {
 # sarge_emit_drift_check_calls) — these wrappers exist only to satisfy
 # the `platform drift_*_fields` dispatch contract.
 ubuntu_drift_snapshot_fields() { _ubuntu_drift_fields | sarge_emit_drift_snapshot_json; }
-ubuntu_drift_check_fields()    { _ubuntu_drift_fields | sarge_emit_drift_check_calls; }
+ubuntu_drift_check_fields()    { sarge_emit_drift_check_calls < <(_ubuntu_drift_fields); }

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -231,37 +231,9 @@ _ubuntu_drift_fields() {
   echo "pass_max_days=${pmd:-unknown}"
 }
 
-# Emit the JSON object body (no surrounding braces) for the Ubuntu
-# snapshot. Each line is `"key": "value",` except the last has no
-# trailing comma — strict JSON, no jq dependency.
-ubuntu_drift_snapshot_fields() {
-  local lines=()
-  local pair k v
-  while IFS= read -r pair; do
-    [[ -z "$pair" ]] && continue
-    k="${pair%%=*}"
-    v="${pair#*=}"
-    lines+=("    \"$k\": \"$v\"")
-  done < <(_ubuntu_drift_fields)
-  local n=${#lines[@]} i=0
-  while [[ $i -lt $n ]]; do
-    if [[ $i -lt $((n - 1)) ]]; then
-      printf '%s,\n' "${lines[$i]}"
-    else
-      printf '%s\n' "${lines[$i]}"
-    fi
-    i=$((i + 1))
-  done
-}
-
-# Run the platform-specific drift comparisons. Caller (compare.sh) must
-# have defined `check <field> <current-value>` in scope before invoking.
-ubuntu_drift_check_fields() {
-  local pair k v
-  while IFS= read -r pair; do
-    [[ -z "$pair" ]] && continue
-    k="${pair%%=*}"
-    v="${pair#*=}"
-    check "$k" "$v"
-  done < <(_ubuntu_drift_fields)
-}
+# Snapshot + compare dispatch entry points. The actual loops live in
+# lib/platforms/_dispatch.sh (sarge_emit_drift_snapshot_json /
+# sarge_emit_drift_check_calls) — these wrappers exist only to satisfy
+# the `platform drift_*_fields` dispatch contract.
+ubuntu_drift_snapshot_fields() { _ubuntu_drift_fields | sarge_emit_drift_snapshot_json; }
+ubuntu_drift_check_fields()    { _ubuntu_drift_fields | sarge_emit_drift_check_calls; }

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -235,5 +235,11 @@ _ubuntu_drift_fields() {
 # lib/platforms/_dispatch.sh (sarge_emit_drift_snapshot_json /
 # sarge_emit_drift_check_calls) — these wrappers exist only to satisfy
 # the `platform drift_*_fields` dispatch contract.
+#
+# The snapshot wrapper uses a pipe; the check wrapper uses process
+# substitution. They look symmetric but they're not — see the rationale
+# block on sarge_emit_drift_check_calls in _dispatch.sh. tl;dr: `check`
+# mutates a DRIFT counter in compare.sh's scope, and a pipe would run
+# the sink in a subshell that drops the mutation.
 ubuntu_drift_snapshot_fields() { _ubuntu_drift_fields | sarge_emit_drift_snapshot_json; }
 ubuntu_drift_check_fields()    { sarge_emit_drift_check_calls < <(_ubuntu_drift_fields); }


### PR DESCRIPTION
## Summary

The two helpers each platform owned — `<os>_drift_snapshot_fields` and `<os>_drift_check_fields` — contained **byte-for-byte identical loop bodies**. Only `_<os>_drift_fields` carries real platform knowledge.

This PR hoists those loops into shared sinks on the dispatcher so a third platform's drift coverage becomes **one function** (the field emitter) instead of three.

## Changes

- `lib/platforms/_dispatch.sh` — adds `sarge_emit_drift_snapshot_json` and `sarge_emit_drift_check_calls`. Both read `key=value` lines on stdin so the platform field emitter pipes naturally into them.
- `lib/platforms/ubuntu.sh` — collapses two 18-line wrappers to one-line pipes.
- `lib/platforms/macos.sh` — same shape.

Dispatch contract (`platform drift_snapshot_fields` / `platform drift_check_fields`) is preserved; the per-platform wrappers still exist, they just delegate.

**Net: −6 lines today. Structural payoff is the 1-vs-3 function shape for the next platform port.**

## Origin

Surfaced by an architecture review of the codebase looking for **deepening opportunities** — shallow modules whose interface is nearly as complex as their implementation. The duplicated drift wrappers were the cleanest case: identical loops, no platform-specific behaviour, copy-pasted between `ubuntu.sh` and `macos.sh` and waiting to be pasted a third time for the Windows port.

## Test plan

- [x] `bash -n` clean on all three edited files
- [x] `drift/snapshot.sh` produces strict JSON with 6 macOS fields and correct no-trailing-comma on the last line — output diffed against pre-refactor snapshot for the same host, identical bytes modulo timestamp
- [x] `drift/compare.sh` immediately after a fresh snapshot reports 0 drift across all 6 fields and exits 0
- [x] `assessment/assess.sh` runs unchanged on macOS (PASS 9 / WARN 3 / FAIL 1 / SKIP 16 on this host)
- [ ] Spot-check on Ubuntu 22.04 / 24.04 before merge (CI?)

## Why this is safe

- No public function names removed; the dispatch contract is unchanged.
- The shared sinks are pure data transformations on stdin — no platform-specific assumptions baked in.
- `sarge_emit_drift_check_calls` still requires `check` in the caller's scope, same as the per-platform versions did.

## Follow-ups (separate PRs)

This is candidate #2 of an architecture review. The next refactor on deck is **the assertion DSL for control checks** (~95 inline verdict ladders across `assessment/checks/*.sh` collapse into a handful of `assert_*` helpers). That will be a separate branch off main after this one merges.