### PR TITLE
fix(platform): distinguish AAD-joined from AD-joined in context schema

### DIFF
--- a/assessment/report/build-report.ps1
+++ b/assessment/report/build-report.ps1
@@ -56,13 +56,22 @@ function Build-SargeReport {
     }
 
     # Load context. Tolerate missing.
+    # Use is_in_managed_domain for the legacy AAD-or-AD union (what this
+    # report's "domain-joined" header has always meant). If the field
+    # isn't present (older context JSON), fall back to the OR of the two
+    # specific fields.
     $ctxPath = Join-Path $StateDir 'windows-context.json'
     $isDomainJoined = $false
     $contextJson = $null
     if (Test-Path -LiteralPath $ctxPath) {
         try {
             $contextJson = Get-Content -LiteralPath $ctxPath -Raw | ConvertFrom-Json
-            $isDomainJoined = [bool]$contextJson.enterprise_context.is_domain_joined
+            $ec = $contextJson.enterprise_context
+            if ($null -ne $ec.is_in_managed_domain) {
+                $isDomainJoined = [bool]$ec.is_in_managed_domain
+            } else {
+                $isDomainJoined = ([bool]$ec.is_domain_joined) -or ([bool]$ec.is_aad_joined)
+            }
         } catch { }
     }
 

--- a/lib/platform.ps1
+++ b/lib/platform.ps1
@@ -131,24 +131,39 @@ function Get-SargeWindowsContext {
         Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
     }
 
+    # `is_domain_joined` is reserved for traditional Active Directory join.
+    # AAD-only join is exposed separately as `is_aad_joined`. The OR-of-both
+    # legacy behaviour is preserved via the new `is_in_managed_domain` field
+    # so existing callers that need "any directory" semantics aren't broken,
+    # but new code should branch on the specific field that matches its
+    # control surface (AD has GPO, AAD has MDM CSP — they're not interchangeable).
     if ($dsreg) {
-        $isDomainJoined = ($dsreg.AzureAdJoined -or $dsreg.DomainJoined)
-        $domainName     = $dsreg.DomainName
-        $intuneManaged  = -not [string]::IsNullOrWhiteSpace($dsreg.MdmUrl)
+        $isDomainJoined    = [bool]$dsreg.DomainJoined
+        $isAadJoined       = [bool]$dsreg.AzureAdJoined
+        $domainName        = $dsreg.DomainName
+        $intuneManaged     = -not [string]::IsNullOrWhiteSpace($dsreg.MdmUrl)
     }
     elseif ($cimComputer) {
-        $isDomainJoined = [bool]$cimComputer.PartOfDomain
-        $domainName     = if ($cimComputer.PartOfDomain) { $cimComputer.Domain } else { $null }
-        $intuneManaged  = $null  # cannot detect Intune without dsregcmd
+        $isDomainJoined    = [bool]$cimComputer.PartOfDomain
+        $isAadJoined       = $null  # cannot detect AAD without dsregcmd
+        $domainName        = if ($cimComputer.PartOfDomain) { $cimComputer.Domain } else { $null }
+        $intuneManaged     = $null  # cannot detect Intune without dsregcmd
         if (-not $probeErrors.ContainsKey('intune_managed')) {
             $probeErrors['intune_managed'] = 'dsregcmd unavailable; cannot detect MDM enrollment without it'
         }
+        if (-not $probeErrors.ContainsKey('is_aad_joined')) {
+            $probeErrors['is_aad_joined'] = 'dsregcmd unavailable; cannot detect AAD join without it'
+        }
     }
     else {
-        $isDomainJoined = $null
-        $domainName     = $null
-        $intuneManaged  = $null
+        $isDomainJoined    = $null
+        $isAadJoined       = $null
+        $domainName        = $null
+        $intuneManaged     = $null
     }
+    $isInManagedDomain = if ($null -ne $isDomainJoined -or $null -ne $isAadJoined) {
+        [bool]$isDomainJoined -or [bool]$isAadJoined
+    } else { $null }
 
     # ---- gpresult: any applied GPOs? ----------------------------------------
     # gpresult /R /SCOPE:USER works as standard user (no elevation). We only
@@ -333,10 +348,12 @@ function Get-SargeWindowsContext {
             windows_build   = $windowsBuild
         }
         enterprise_context = [ordered]@{
-            is_domain_joined = $isDomainJoined
-            domain_name      = $domainName
-            intune_managed   = $intuneManaged
-            gpo_present      = $gpoPresent
+            is_domain_joined     = $isDomainJoined
+            is_aad_joined        = $isAadJoined
+            is_in_managed_domain = $isInManagedDomain
+            domain_name          = $domainName
+            intune_managed       = $intuneManaged
+            gpo_present          = $gpoPresent
         }
         active_controls    = [ordered]@{
             applocker_active           = $applockerActive


### PR DESCRIPTION
## Summary

- Splits Phase 1a's overloaded \`is_domain_joined\` into three correctly-named fields
- Additive schema change — \`is_domain_joined\` semantically corrected (now strictly AD); \`is_aad_joined\` + \`is_in_managed_domain\` added
- \`build-report.ps1\` updated to read \`is_in_managed_domain\` so the report header behavior is unchanged

## Why

The Phase 1b policy-mode classifier (PR #37) needs to distinguish AAD-only hosts from traditional AD-joined hosts because their managed-policy mechanisms differ (GPO vs MDM CSP). Phase 1a's existing OR-of-both \`is_domain_joined\` made that impossible at the context layer.

Surfaced as a known quirk in PR #37's heads-up issue #38. Fixing in a small standalone PR keeps it auditable.

## Schema (issue #13 contract, additive only)

\`\`\`
enterprise_context:
  is_domain_joined     — now strictly traditional AD-joined (was: AAD || AD)
  is_aad_joined        — NEW, true on AAD-only or hybrid hosts
  is_in_managed_domain — NEW, the OR — for callers that legitimately want
                         "any directory" semantics
  domain_name          — unchanged
  intune_managed       — unchanged
  gpo_present          — unchanged
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)