### PR TITLE
refactor(bash): per-run folder layout for assess + drift + report

### DIFF
--- a/assessment/assess.sh
+++ b/assessment/assess.sh
@@ -38,11 +38,20 @@ STATE_DIR="${SARGE_STATE_DIR:-$HOME/.sarge/state}"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 REPORT_BASE="${REPORT_DIR}/sarge-report-${TIMESTAMP}"
 
+# Per-run folder layout (mirrors the Windows port — PR #32, issue #34).
+# Every artifact for THIS run lands under $SARGE_RUN_ROOT in addition to
+# the legacy $REPORT_DIR / $STATE_DIR paths, so downstream consumers that
+# read from the old locations keep working while new tooling can rely on
+# a single self-contained per-run directory.
+SARGE_RUN_ID="${SARGE_RUN_ID:-$TIMESTAMP}"
+SARGE_RUN_ROOT="${SARGE_RUN_ROOT:-$HOME/.sarge/runs/$SARGE_RUN_ID}"
+export SARGE_RUN_ID SARGE_RUN_ROOT
+
 # Counters
 PASS=0; WARN=0; FAIL=0; SKIP=0
 declare -a RESULTS=()
 
-mkdir -p "$REPORT_DIR" "$STATE_DIR"
+mkdir -p "$REPORT_DIR" "$STATE_DIR" "$SARGE_RUN_ROOT"
 
 # Initialize install timestamp on first run
 INSTALLED_AT_FILE="$STATE_DIR/installed-at.txt"
@@ -108,7 +117,10 @@ log "======================================"
   --output "$REPORT_BASE" \
   --report-dir "$REPORT_DIR" \
   --state-dir "$STATE_DIR" \
+  --run-root "$SARGE_RUN_ROOT" \
+  --run-id "$SARGE_RUN_ID" \
   --catalog "$SCRIPT_DIR/findings-catalog.json" \
   --results "$(printf '%s\n' "${RESULTS[@]}")" || true
 
 log "Reports written to: $REPORT_BASE.md and $REPORT_BASE.json"
+log "Run folder: $SARGE_RUN_ROOT"

--- a/assessment/report/report.sh
+++ b/assessment/report/report.sh
@@ -11,6 +11,8 @@ OUTPUT=""
 RESULTS=""
 REPORT_DIR=""
 STATE_DIR=""
+RUN_ROOT=""
+RUN_ID=""
 CATALOG=""
 
 while [[ $# -gt 0 ]]; do
@@ -23,6 +25,8 @@ while [[ $# -gt 0 ]]; do
     --results) RESULTS="$2"; shift 2 ;;
     --report-dir) REPORT_DIR="$2"; shift 2 ;;
     --state-dir) STATE_DIR="$2"; shift 2 ;;
+    --run-root) RUN_ROOT="$2"; shift 2 ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
     --catalog) CATALOG="$2"; shift 2 ;;
     *) shift ;;
   esac
@@ -33,10 +37,12 @@ done
 # Defaults
 REPORT_DIR="${REPORT_DIR:-$HOME/.sarge/reports}"
 STATE_DIR="${STATE_DIR:-$HOME/.sarge/state}"
+RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
+RUN_ROOT="${RUN_ROOT:-$HOME/.sarge/runs/$RUN_ID}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CATALOG="${CATALOG:-$SCRIPT_DIR/../findings-catalog.json}"
 
-mkdir -p "$REPORT_DIR" "$STATE_DIR"
+mkdir -p "$REPORT_DIR" "$STATE_DIR" "$RUN_ROOT"
 
 TIMESTAMP=$(date -Iseconds)
 TOTAL=$((PASS+WARN+FAIL+SKIP))
@@ -54,11 +60,20 @@ DRIFT_COUNT=0
 [[ -f "$DRIFT_COUNT_FILE" ]] && DRIFT_COUNT=$(cat "$DRIFT_COUNT_FILE" 2>/dev/null || echo 0)
 [[ -z "$DRIFT_COUNT" ]] && DRIFT_COUNT=0
 
-# --- Find previous report (most recent JSON in REPORT_DIR, excluding the
-# one we are about to write). Filenames sort lexically by timestamp. ---
+# --- Find previous report. Prefer the per-run folder layout (issue #34):
+# scan ~/.sarge/runs/*/report.json and pick the lexically-latest one that
+# isn't our current run. Fall back to the legacy REPORT_DIR scan so the
+# delta panel keeps working on hosts that ran older Sarge releases. ---
 CURRENT_JSON_BASENAME="$(basename "$OUTPUT").json"
+RUNS_ROOT="$(dirname "$RUN_ROOT")"
+CURRENT_RUN_BASENAME="$(basename "$RUN_ROOT")"
 PREV_JSON=""
-if [[ -d "$REPORT_DIR" ]]; then
+if [[ -d "$RUNS_ROOT" ]]; then
+  PREV_JSON=$(find "$RUNS_ROOT" -mindepth 2 -maxdepth 2 -type f -name 'report.json' 2>/dev/null \
+              | awk -v cur="$CURRENT_RUN_BASENAME" -F/ '$(NF-1) != cur' \
+              | sort | tail -n1)
+fi
+if [[ -z "$PREV_JSON" && -d "$REPORT_DIR" ]]; then
   PREV_JSON=$(find "$REPORT_DIR" -maxdepth 1 -type f -name 'sarge-report-*.json' \
               ! -name "$CURRENT_JSON_BASENAME" 2>/dev/null \
               | sort | tail -n1)
@@ -287,6 +302,10 @@ INSTALL_DATE_HUMAN="$INSTALLED_AT"
   echo "_Assessment timestamp: ${TIMESTAMP}_"
 } > "${OUTPUT}.md"
 
+# Per-run folder copy (issue #34): mirror the Markdown report into the
+# self-contained run directory alongside report.json and findings.json.
+cp "${OUTPUT}.md" "${RUN_ROOT}/report.md"
+
 # --- Build JSON report ---
 # Use jq when available for safe escaping; otherwise hand-roll.
 if command -v jq &>/dev/null; then
@@ -387,4 +406,41 @@ else
     echo "  ]"
     echo "}"
   } > "${OUTPUT}.json"
+fi
+
+# Per-run folder copies (issue #34): keep the legacy REPORT_DIR writes
+# above for backwards compatibility, and also publish the JSON report and
+# a standalone findings.json under $RUN_ROOT so the run directory is
+# self-contained.
+cp "${OUTPUT}.json" "${RUN_ROOT}/report.json"
+
+# findings.json: just the results array, mirroring the Windows
+# build-report.ps1 output shape (a flat array of finding objects).
+if command -v jq &>/dev/null; then
+  printf '%s\n' "${ALL_LINES[@]}" | jq -R -s '
+    split("\n")
+    | map(select(length > 0))
+    | map(split("|"))
+    | map({
+        status: .[0],
+        check_id: (.[1] // ""),
+        detail: (.[2:] | join("|"))
+      })
+  ' > "${RUN_ROOT}/findings.json"
+else
+  # Hand-rolled fallback — same best-effort escaping as the JSON report.
+  {
+    echo "["
+    n=${#ALL_LINES[@]}; i=0
+    for line in "${ALL_LINES[@]}"; do
+      i=$((i+1))
+      status=$(echo "$line" | awk -F'|' '{print $1}')
+      check_id=$(echo "$line" | awk -F'|' '{print $2}')
+      detail=$(echo "$line" | awk -F'|' '{ for (k=3;k<=NF;k++) { printf "%s%s", (k==3?"":"|"), $k } }')
+      detail_escaped=$(printf '%s' "$detail" | sed 's/\\/\\\\/g; s/"/\\"/g')
+      sep=","; [[ "$i" -eq "$n" ]] && sep=""
+      echo "  {\"status\": \"${status}\", \"check_id\": \"${check_id}\", \"detail\": \"${detail_escaped}\"}${sep}"
+    done
+    echo "]"
+  } > "${RUN_ROOT}/findings.json"
 fi

--- a/drift/compare.sh
+++ b/drift/compare.sh
@@ -18,6 +18,16 @@ LATEST="$SNAPSHOT_DIR/latest.json"
 
 [[ -f "$LATEST" ]] || { echo "[Sarge] No snapshot found. Run snapshot.sh first."; exit 1; }
 
+# Per-run folder layout (issue #34). Standalone compare.sh invocations get
+# a fresh run root; when assess.sh / drift-cron.sh exports one we reuse it.
+SARGE_RUN_ID="${SARGE_RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
+SARGE_RUN_ROOT="${SARGE_RUN_ROOT:-$HOME/.sarge/runs/$SARGE_RUN_ID}"
+mkdir -p "$SARGE_RUN_ROOT"
+export SARGE_RUN_ID SARGE_RUN_ROOT
+DRIFT_REPORT="$SARGE_RUN_ROOT/drift-report.json"
+DRIFT_ITEMS_FILE="$(mktemp)"
+trap 'rm -f "$DRIFT_ITEMS_FILE"' EXIT
+
 # The platform's drift_check_fields function calls this helper for each
 # field it knows about. Reads the baseline value out of the snapshot JSON
 # via a python one-liner (python3 is on every supported platform); falls
@@ -45,9 +55,11 @@ PY
   baseline=${baseline:-unknown}
   if [[ "$current" == "$baseline" ]]; then
     echo "  [OK]   $field: $current"
+    printf '%s\t%s\t%s\t%s\n' "ok" "$field" "$baseline" "$current" >> "$DRIFT_ITEMS_FILE"
   else
     echo "  [DRIFT] $field: was '$baseline', now '$current'"
     DRIFT=$((DRIFT+1))
+    printf '%s\t%s\t%s\t%s\n' "drift" "$field" "$baseline" "$current" >> "$DRIFT_ITEMS_FILE"
   fi
 }
 
@@ -62,6 +74,54 @@ echo "[Sarge] Drift Detection — comparing against ${SNAP_MTIME}"
 platform drift_check_fields
 
 echo ""
+
+# Write per-run drift-report.json (issue #34). Self-contained machine-
+# readable view of this compare invocation; the legacy stdout summary
+# above is unchanged so existing log scrapers keep working.
+NOW_TS=$(date -Iseconds 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+if command -v jq &>/dev/null; then
+  jq -R -s \
+    --arg ts "$NOW_TS" \
+    --arg host "$(hostname)" \
+    --arg snapshot "$LATEST" \
+    --argjson drift_count "$DRIFT" \
+    '{
+      timestamp: $ts,
+      host: $host,
+      baseline_snapshot: $snapshot,
+      drift_count: $drift_count,
+      items: (
+        split("\n")
+        | map(select(length > 0))
+        | map(split("\t"))
+        | map({status: .[0], field: .[1], baseline: .[2], current: .[3]})
+      )
+    }' < "$DRIFT_ITEMS_FILE" > "$DRIFT_REPORT" 2>/dev/null || true
+else
+  {
+    echo "{"
+    echo "  \"timestamp\": \"${NOW_TS}\","
+    echo "  \"host\": \"$(hostname)\","
+    echo "  \"baseline_snapshot\": \"${LATEST}\","
+    echo "  \"drift_count\": ${DRIFT},"
+    echo "  \"items\": ["
+    total_lines=$(wc -l < "$DRIFT_ITEMS_FILE" | tr -d ' ')
+    idx=0
+    while IFS=$'\t' read -r st field baseline current; do
+      idx=$((idx+1))
+      esc_baseline=$(printf '%s' "$baseline" | sed 's/\\/\\\\/g; s/"/\\"/g')
+      esc_current=$(printf '%s' "$current" | sed 's/\\/\\\\/g; s/"/\\"/g')
+      sep=","; [[ "$idx" -eq "$total_lines" ]] && sep=""
+      echo "    {\"status\": \"${st}\", \"field\": \"${field}\", \"baseline\": \"${esc_baseline}\", \"current\": \"${esc_current}\"}${sep}"
+    done < "$DRIFT_ITEMS_FILE"
+    echo "  ]"
+    echo "}"
+  } > "$DRIFT_REPORT"
+fi
+
+echo "[Sarge] Drift report: $DRIFT_REPORT"
+echo "[Sarge] Run folder:   $SARGE_RUN_ROOT"
+
 if [[ "$DRIFT" -eq 0 ]]; then
   echo "[Sarge] No drift detected. Configuration matches baseline."
 else

--- a/drift/snapshot.sh
+++ b/drift/snapshot.sh
@@ -18,6 +18,15 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 SNAPSHOT_FILE="$SNAPSHOT_DIR/snapshot-${TIMESTAMP}.json"
 mkdir -p "$SNAPSHOT_DIR"
 
+# Per-run folder layout (issue #34). When the caller hasn't already
+# established a run root (e.g. snapshot.sh invoked standalone, outside
+# assess.sh), create one here so the snapshot lands in a self-contained
+# folder under ~/.sarge/runs/.
+SARGE_RUN_ID="${SARGE_RUN_ID:-$TIMESTAMP}"
+SARGE_RUN_ROOT="${SARGE_RUN_ROOT:-$HOME/.sarge/runs/$SARGE_RUN_ID}"
+mkdir -p "$SARGE_RUN_ROOT"
+export SARGE_RUN_ID SARGE_RUN_ROOT
+
 echo "[Sarge] Taking baseline snapshot..."
 
 # Platform-specific fields are emitted by `platform drift_snapshot_fields`
@@ -39,3 +48,9 @@ EOF
 
 echo "[Sarge] Snapshot saved: $SNAPSHOT_FILE"
 ln -sf "$SNAPSHOT_FILE" "$SNAPSHOT_DIR/latest.json"
+
+# Mirror into the per-run folder. compare.sh still reads from the legacy
+# SNAPSHOT_DIR/latest.json so the baseline survives across runs — the
+# in-run copy is for archival/self-contained-run-folder purposes only.
+cp "$SNAPSHOT_FILE" "$SARGE_RUN_ROOT/drift-snapshot.json"
+echo "[Sarge] Run folder: $SARGE_RUN_ROOT"


### PR DESCRIPTION
## Summary

Mirrors the Windows port pattern from PR #32 on the bash side. Every run now writes a self-contained directory under `~/.sarge/runs/<YYYYMMDD-HHmmss>/` containing `report.md`, `report.json`, `findings.json`, and (for drift runs) `drift-snapshot.json` + `drift-report.json`.

Legacy writes under `~/.sarge/state/` and `~/.sarge/reports/` are preserved for backwards compatibility with downstream consumers (Phase 1a contract, issue #12 / PR #14).

Closes #34.

## Changes

- `assessment/assess.sh` — compute `SARGE_RUN_ID` once at startup, export `SARGE_RUN_ROOT`, create the directory, pass `--run-root` / `--run-id` to `report.sh`, print `[SARGE] Run folder: ...` on completion.
- `assessment/report/report.sh` — accept `--run-root` / `--run-id`; mirror `report.md`, `report.json`, `findings.json` into the run folder. Previous-run delta lookup prefers `~/.sarge/runs/*/report.json` with legacy `REPORT_DIR` fallback.
- `drift/snapshot.sh` — also copy snapshot into `$SARGE_RUN_ROOT/drift-snapshot.json`; legacy `SNAPSHOT_DIR/latest.json` unchanged.
- `drift/compare.sh` — emit `$SARGE_RUN_ROOT/drift-report.json` (jq + hand-rolled fallback).

## Out of scope

- Windows side (`*.ps1`) — already on per-run layout from PR #32.
- `assessment/checks/check-*.sh` — they don't write to disk directly; their interface is preserved.

## Test plan

- [x] `bash -n` on every modified file + every check-*.sh + drift-cron.sh — clean
- [x] Fresh `assess.sh` on Ubuntu 24+: produces `~/.sarge/runs/<ts>/{report.md,report.json,findings.json}` (50 findings)
- [x] Second `assess.sh` run picks up prior run for delta computation
- [x] `snapshot.sh` then `compare.sh` — both files land in the run folder
- [x] Legacy paths still written
- [ ] macOS — not tested (no host available); POSIX-safe paths and existing GNU/BSD `date` fallbacks preserved

## Caveats

- `shellcheck` not available on this dev host; manual review only.