### PR TITLE
feat(backup): macOS pre-hardening APFS snapshot + rollback (untested on real hw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,90 @@ Sarge scripts use exit codes to signal *what they did*, not just *whether they s
 
 ---
 
+## Pre-hardening backup + rollback (macOS)
+
+> **Untested on real macOS hardware.** Oscar Six does not currently have
+> a Mac test surface available. The macOS backup + rollback scripts
+> (`scripts/backup-macos.sh`, `scripts/rollback-macos.sh`) follow the
+> issue [#30](https://github.com/oscarsixsecllc/sarge/issues/30) spec
+> and the Ubuntu/Windows backup patterns, but have only been exercised
+> via `bash -n` and a Linux dry-run smoke test
+> (`tests/integration/backup-macos-smoke.sh`). The macOS-specific
+> commands (`tmutil`, `pfctl`, `defaults`, `socketfilterfw`, `csrutil`,
+> `spctl`, `fdesetup`, `launchctl`) have **not** been validated against
+> live binaries. **Community validation contributions are welcome** —
+> open a PR or comment on issue #30 with results from a real Mac.
+
+Before any `harden-*.sh` runs on macOS, Sarge captures a layered backup
+so any change is reversible:
+
+1. **APFS local snapshot** (heavy-lift backstop) via `tmutil localsnapshot`.
+   Survives reboots, costs no extra disk until divergence, restorable
+   via `tmutil restore <snapshot-id>`. The script **fails loudly** if
+   the boot volume isn't APFS or local snapshots are disabled — it does
+   not silently proceed.
+2. **Optional Time Machine snapshot** via `tmutil startbackup --block`
+   when `--time-machine` is passed and TM is configured. Slower;
+   complements the APFS snapshot.
+3. **File-level capture** under `~/.sarge/runs/<run-id>/backup/`:
+   - `/etc/pam.d/`, `/etc/ssh/sshd_config`, `/etc/sudoers.d/`,
+     `/etc/security/audit_*` copied with `cp -Rp`
+   - `socketfilterfw --getglobalstate` + per-app rules → `socketfilterfw.txt`
+   - `pfctl -sa` → `pf-state.txt`
+   - `launchctl list` → `launchctl.txt`
+   - `defaults read` of touched domains (`com.apple.loginwindow`,
+     `com.apple.screensaver`, `com.apple.security`,
+     `/Library/Preferences/com.apple.alf`) → `defaults-<domain>.txt`
+   - `csrutil status`, `spctl --status`, `fdesetup status` →
+     `security-status.txt`
+4. **Generated `rollback.sh`** that reverses each granular artifact
+   (cp `/etc/` back, `pfctl -f` the saved state, re-enable
+   socketfilterfw, replay launchctl delta, defaults manual-review
+   pointer) and documents the APFS snapshot ID as the backstop.
+5. **`summary.md`** with capture inventory + both rollback paths.
+
+### Usage
+
+```bash
+# Interactive (prompts before snapshot)
+bash scripts/backup-macos.sh --run-id "$SARGE_RUN_ID"
+
+# Unattended (CI / chained from assess.sh)
+bash scripts/backup-macos.sh --unattended --run-id "$SARGE_RUN_ID"
+
+# Also trigger a Time Machine snapshot
+bash scripts/backup-macos.sh --unattended --time-machine --run-id "$SARGE_RUN_ID"
+
+# Roll back the most recent run
+bash scripts/rollback-macos.sh --latest
+
+# Roll back a specific run
+bash scripts/rollback-macos.sh --run-id 20260523-120000
+```
+
+### Heavy-lift fallback
+
+If granular rollback fails or leaves the system in an unexpected state,
+restore the APFS local snapshot:
+
+```bash
+tmutil listlocalsnapshots /
+tmutil restore <snapshot-id-from-summary.md>
+```
+
+### Phase 2 follow-ups (tracked as untested debt)
+
+- `defaults read` capture is human-readable, not directly importable
+  by `defaults import`. Phase 2 should switch to
+  `defaults export <domain> <file>.plist` so `rollback.sh` can
+  re-import non-interactively.
+- `pfctl -sa` is a mixed-section dump; a finer-grained `pfctl -sr`
+  capture would let `rollback.sh` reload rules deterministically.
+- `socketfilterfw` per-app rules have no bulk-import; rollback emits
+  the captured `--listapps` output for manual replay.
+
+---
+
 ## Repository Structure
 
 ```

--- a/scripts/backup-macos.sh
+++ b/scripts/backup-macos.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# backup-macos.sh — Sarge pre-hardening backup (macOS)
+# NIST 800-53 CP-9 / CP-10 | Oscar Six Security LLC
+#
+# UNTESTED ON REAL macOS HARDWARE: Oscar Six does not have a Mac test
+# surface available. This script follows the spec in issue #30 and the
+# Ubuntu/Windows backup-script patterns, but has not been exercised
+# against `tmutil`, `pfctl`, `socketfilterfw`, `defaults`, `csrutil`,
+# `spctl`, or `fdesetup` on a live macOS host. The `bash -n` syntax
+# check and the dry-run smoke test in tests/integration/ are the only
+# validation performed. Community validation contributions welcome —
+# see README.md "Pre-hardening backup + rollback (macOS)".
+#
+# Per-run folder pattern matches PR #42 (issue #34):
+#   ~/.sarge/runs/<run_id>/backup/
+#
+# Heavy-lift backstop is an APFS local snapshot (tmutil localsnapshot),
+# reversible via `tmutil restore <snapshot>`. File-level rollback.sh is
+# emitted alongside for granular reverts.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# -----------------------------------------------------------------------------
+# Platform guard — macOS only. Lets the dry-run smoke test on Linux exit
+# cleanly with a clear message.
+# -----------------------------------------------------------------------------
+UNAME_S="$(uname -s 2>/dev/null || echo unknown)"
+DRY_RUN="${SARGE_BACKUP_DRY_RUN:-0}"
+
+if [[ "$UNAME_S" != "Darwin" && "$DRY_RUN" != "1" ]]; then
+  echo "[Sarge] backup-macos.sh: macOS only (detected: ${UNAME_S})." >&2
+  echo "[Sarge] Set SARGE_BACKUP_DRY_RUN=1 to exercise the dry-run path on non-Darwin." >&2
+  exit 2
+fi
+
+# -----------------------------------------------------------------------------
+# Argument parsing
+# -----------------------------------------------------------------------------
+UNATTENDED=0
+RUN_ID=""
+INCLUDE_TIME_MACHINE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --unattended)        UNATTENDED=1; shift ;;
+    --run-id)            RUN_ID="${2:-}"; shift 2 ;;
+    --run-id=*)          RUN_ID="${1#*=}"; shift ;;
+    --time-machine)      INCLUDE_TIME_MACHINE=1; shift ;;
+    -h|--help)
+      cat <<EOF
+Usage: backup-macos.sh [options]
+
+Options:
+  --unattended         Skip interactive prompts (assume APFS snapshot, no TM)
+  --run-id <id>        Reuse a run ID established by assess.sh
+  --time-machine       Also trigger a Time Machine snapshot (slower)
+  -h, --help           This message
+
+Environment:
+  SARGE_BACKUP_DRY_RUN=1   Stub all macOS-only commands via PATH; do not
+                           execute snapshots. Used by tests/integration/.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "[Sarge] backup-macos.sh: unknown arg '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RUN_ID="${RUN_ID:-${SARGE_RUN_ID:-$TIMESTAMP}}"
+SARGE_RUN_ROOT="${SARGE_RUN_ROOT:-$HOME/.sarge/runs/$RUN_ID}"
+BACKUP_DIR="$SARGE_RUN_ROOT/backup"
+mkdir -p "$BACKUP_DIR"
+
+log() { echo "[Sarge][backup-macos] $*"; }
+warn() { echo "[Sarge][backup-macos][WARN] $*" >&2; }
+die()  { echo "[Sarge][backup-macos][FATAL] $*" >&2; exit 1; }
+
+log "Run ID:      $RUN_ID"
+log "Backup dir:  $BACKUP_DIR"
+log "Dry run:     $DRY_RUN"
+
+# -----------------------------------------------------------------------------
+# Interactive consent (skipped under --unattended)
+# -----------------------------------------------------------------------------
+if [[ "$UNATTENDED" != "1" && "$DRY_RUN" != "1" ]]; then
+  read -r -p "[Sarge] Take APFS local snapshot + capture mutable state before hardening? [Y/n] " ans
+  case "${ans:-Y}" in
+    Y|y|"") ;;
+    *) die "User declined backup. Refusing to proceed (hardening blocked until --unattended or consent)." ;;
+  esac
+fi
+
+# -----------------------------------------------------------------------------
+# 1. APFS local snapshot — fail loudly if boot volume isn't APFS.
+# -----------------------------------------------------------------------------
+APFS_SNAPSHOT_ID=""
+APFS_SNAPSHOT_STATUS="not-attempted"
+
+apfs_check_boot_volume() {
+  # Boot volume must be APFS for `tmutil localsnapshot` to work.
+  # `diskutil info /` reports the file system personality.
+  local fs
+  if ! fs="$(diskutil info / 2>/dev/null | awk -F: '/File System Personality/ {gsub(/^ +| +$/,"",$2); print $2; exit}')"; then
+    return 1
+  fi
+  [[ "$fs" == *APFS* ]]
+}
+
+take_apfs_snapshot() {
+  log "Requesting APFS local snapshot via tmutil localsnapshot ..."
+  local out
+  if ! out="$(tmutil localsnapshot 2>&1)"; then
+    APFS_SNAPSHOT_STATUS="failed"
+    warn "tmutil localsnapshot failed: $out"
+    return 1
+  fi
+  # tmutil emits a line like:
+  #   Created local snapshot with date: 2026-05-23-120000
+  APFS_SNAPSHOT_ID="$(printf '%s\n' "$out" | awk '/Created local snapshot/ {print $NF; exit}')"
+  APFS_SNAPSHOT_STATUS="created"
+  printf '%s\n' "$out" > "$BACKUP_DIR/apfs-snapshot.txt"
+  log "APFS snapshot created: ${APFS_SNAPSHOT_ID:-unknown-id}"
+}
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "[DRY-RUN] Would run: diskutil info / | grep 'File System Personality'"
+  log "[DRY-RUN] Would run: tmutil localsnapshot"
+  APFS_SNAPSHOT_ID="dry-run-snapshot"
+  APFS_SNAPSHOT_STATUS="dry-run"
+  echo "DRY-RUN: tmutil localsnapshot would have been invoked" > "$BACKUP_DIR/apfs-snapshot.txt"
+else
+  if ! apfs_check_boot_volume; then
+    die "Boot volume is not APFS — refusing to proceed. Pre-hardening backup requires APFS local snapshots."
+  fi
+  if ! take_apfs_snapshot; then
+    die "APFS local snapshot failed. Local snapshots may be disabled. Aborting — see https://support.apple.com/HT204015"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# 2. Optional Time Machine snapshot
+# -----------------------------------------------------------------------------
+TM_STATUS="skipped"
+if [[ "$INCLUDE_TIME_MACHINE" == "1" ]]; then
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "[DRY-RUN] Would run: tmutil startbackup --block"
+    TM_STATUS="dry-run"
+    echo "DRY-RUN: tmutil startbackup --block would have been invoked" > "$BACKUP_DIR/time-machine.txt"
+  else
+    log "Triggering Time Machine snapshot (this may be slow)..."
+    if tmutil startbackup --block > "$BACKUP_DIR/time-machine.txt" 2>&1; then
+      TM_STATUS="completed"
+    else
+      TM_STATUS="failed"
+      warn "Time Machine snapshot failed — APFS local snapshot still covers rollback."
+    fi
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# 3. File-level snapshots (run regardless of volume-snapshot success)
+# -----------------------------------------------------------------------------
+ETC_BACKUP="$BACKUP_DIR/etc"
+mkdir -p "$ETC_BACKUP"
+
+copy_etc() {
+  local src="$1"
+  local dst_rel="${src#/}"
+  local dst="$ETC_BACKUP/$dst_rel"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "[DRY-RUN] Would copy $src -> $dst"
+    mkdir -p "$(dirname "$dst")"
+    : > "$dst"
+    return 0
+  fi
+  if [[ ! -e "$src" ]]; then
+    warn "Source not present, skipping: $src"
+    return 0
+  fi
+  mkdir -p "$(dirname "$dst")"
+  # -p preserves perms; -R for dirs; -a preserves more but isn't portable
+  cp -Rp "$src" "$dst" || warn "cp failed for $src"
+}
+
+log "Capturing /etc files ..."
+copy_etc "/etc/pam.d"
+copy_etc "/etc/ssh/sshd_config"
+copy_etc "/etc/sudoers.d"
+
+# audit_* glob — expand carefully
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "[DRY-RUN] Would copy /etc/security/audit_* -> $ETC_BACKUP/etc/security/"
+  mkdir -p "$ETC_BACKUP/etc/security"
+  : > "$ETC_BACKUP/etc/security/audit_control"
+else
+  mkdir -p "$ETC_BACKUP/etc/security"
+  shopt -s nullglob
+  for f in /etc/security/audit_*; do
+    cp -Rp "$f" "$ETC_BACKUP/etc/security/" 2>/dev/null || warn "cp failed for $f"
+  done
+  shopt -u nullglob
+fi
+
+# socketfilterfw — application-layer firewall
+log "Capturing socketfilterfw state ..."
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "[DRY-RUN] Would run: /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate"
+  echo "DRY-RUN socketfilterfw" > "$BACKUP_DIR/socketfilterfw.txt"
+else
+  {
+    echo "### /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate"
+    /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>&1 || true
+    echo
+    echo "### --getblockall"
+    /usr/libexec/ApplicationFirewall/socketfilterfw --getblockall 2>&1 || true
+    echo
+    echo "### --getallowsigned"
+    /usr/libexec/ApplicationFirewall/socketfilterfw --getallowsigned 2>&1 || true
+    echo
+    echo "### --listapps"
+    /usr/libexec/ApplicationFirewall/socketfilterfw --listapps 2>&1 || true
+  } > "$BACKUP_DIR/socketfilterfw.txt"
+fi
+
+# pfctl — packet filter
+log "Capturing pf state ..."
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "[DRY-RUN] Would run: pfctl -sa"
+  echo "DRY-RUN pfctl -sa" > "$BACKUP_DIR/pf-state.txt"
+else
+  sudo -n pfctl -sa > "$BACKUP_DIR/pf-state.txt" 2>&1 || \
+    pfctl -sa > "$BACKUP_DIR/pf-state.txt" 2>&1 || \
+    warn "pfctl -sa failed (may need sudo). State partial."
+fi
+
+# launchctl
+log "Capturing launchctl service inventory ..."
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "[DRY-RUN] Would run: launchctl list"
+  echo "DRY-RUN launchctl list" > "$BACKUP_DIR/launchctl.txt"
+else
+  launchctl list > "$BACKUP_DIR/launchctl.txt" 2>&1 || warn "launchctl list failed."
+fi
+
+# defaults read — touched domains (Phase 2 has not enumerated final set;
+# this is the starting list per issue #30).
+DEFAULTS_DOMAINS=(
+  "com.apple.loginwindow"
+  "com.apple.screensaver"
+  "com.apple.security"
+  "/Library/Preferences/com.apple.alf"
+)
+
+log "Capturing defaults for ${#DEFAULTS_DOMAINS[@]} domains ..."
+for domain in "${DEFAULTS_DOMAINS[@]}"; do
+  # Use a slug derived from the domain for the filename
+  slug="$(printf '%s' "$domain" | tr '/' '_' | tr ' ' '_')"
+  out="$BACKUP_DIR/defaults-${slug}.txt"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "[DRY-RUN] Would run: defaults read $domain"
+    echo "DRY-RUN defaults read $domain" > "$out"
+  else
+    defaults read "$domain" > "$out" 2>&1 || warn "defaults read failed for $domain"
+  fi
+done
+
+# Security posture probes
+log "Capturing security posture (csrutil/spctl/fdesetup) ..."
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "[DRY-RUN] Would run: csrutil status; spctl --status; fdesetup status"
+  cat > "$BACKUP_DIR/security-status.txt" <<EOF
+DRY-RUN csrutil status
+DRY-RUN spctl --status
+DRY-RUN fdesetup status
+EOF
+else
+  {
+    echo "### csrutil status"
+    csrutil status 2>&1 || true
+    echo
+    echo "### spctl --status"
+    spctl --status 2>&1 || true
+    echo
+    echo "### fdesetup status"
+    fdesetup status 2>&1 || true
+  } > "$BACKUP_DIR/security-status.txt"
+fi
+
+# -----------------------------------------------------------------------------
+# 4. Emit rollback.sh
+# -----------------------------------------------------------------------------
+ROLLBACK_SH="$BACKUP_DIR/rollback.sh"
+cat > "$ROLLBACK_SH" <<ROLLBACK
+#!/usr/bin/env bash
+# rollback.sh — Sarge pre-hardening rollback (macOS)
+# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Run ID:    $RUN_ID
+#
+# This script reverses each granular artifact captured under:
+#   $BACKUP_DIR
+#
+# The heavy-lift backstop is the APFS local snapshot — if granular
+# rollback fails or the system is in a worse state than expected, you
+# can restore the whole boot volume with:
+#
+#     tmutil restore $APFS_SNAPSHOT_ID
+#
+# (See: man tmutil — restore. Reboot to the macOS Recovery environment
+# if a live restore can't proceed.)
+#
+# UNTESTED ON REAL macOS HARDWARE — verify before relying on in
+# production. See https://github.com/oscarsixsecllc/sarge/issues/30.
+
+set -uo pipefail
+
+if [[ "\$(uname -s)" != "Darwin" ]]; then
+  echo "[Sarge] rollback.sh: macOS only." >&2
+  exit 2
+fi
+
+BACKUP_DIR="\${BACKUP_DIR:-$BACKUP_DIR}"
+ETC_BACKUP="\$BACKUP_DIR/etc"
+
+echo "[Sarge] rollback.sh: restoring from \$BACKUP_DIR"
+
+# --- 1. /etc files ---
+if [[ -d "\$ETC_BACKUP/etc" ]]; then
+  echo "[Sarge] Restoring /etc files (requires sudo)..."
+  # Walk the saved tree and cp -Rp back into place.
+  (cd "\$ETC_BACKUP" && find etc -mindepth 1 -maxdepth 1 -print0) | while IFS= read -r -d '' entry; do
+    sudo cp -Rp "\$ETC_BACKUP/\$entry" "/\$entry" || echo "[Sarge][WARN] cp back failed for /\$entry"
+  done
+fi
+
+# --- 2. pf rules ---
+if [[ -s "\$BACKUP_DIR/pf-state.txt" ]]; then
+  echo "[Sarge] Re-applying pf rules (best-effort)..."
+  # pfctl -sa output is human-readable, not directly loadable. We restore
+  # the saved anchors/rules conservatively: if the captured output contains
+  # a rules section, pipe it back through pfctl -f -. If no parseable rules
+  # are present, fall back to disabling any new anchors Sarge added.
+  if grep -q "^scrub\|^block\|^pass" "\$BACKUP_DIR/pf-state.txt" 2>/dev/null; then
+    # Extract a rules-only view; this is best-effort because pfctl -sa
+    # interleaves multiple sections. Real restore should use a snapshot of
+    # pfctl -sr captured BEFORE the hardening change — Phase 2 should
+    # supplement this script with that finer-grained capture.
+    sudo pfctl -f "\$BACKUP_DIR/pf-state.txt" 2>/dev/null || \
+      echo "[Sarge][WARN] pfctl -f failed; consider 'tmutil restore $APFS_SNAPSHOT_ID' for a clean rollback."
+  fi
+fi
+
+# --- 3. socketfilterfw rules ---
+if [[ -s "\$BACKUP_DIR/socketfilterfw.txt" ]]; then
+  echo "[Sarge] Re-applying socketfilterfw global state (best-effort)..."
+  # socketfilterfw has no native bulk-import; replay flags from the saved
+  # globalstate. Per-app rules in --listapps need to be re-added with
+  # --add <path>; this is best-effort per the captured output.
+  if grep -q "Firewall is enabled" "\$BACKUP_DIR/socketfilterfw.txt" 2>/dev/null; then
+    sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on 2>/dev/null || true
+  fi
+fi
+
+# --- 4. defaults import ---
+for f in "\$BACKUP_DIR"/defaults-*.txt; do
+  [[ -e "\$f" ]] || continue
+  # defaults read produces a plist-style dump — not directly importable.
+  # Phase 2 should switch the capture step to 'defaults export <domain> <file>.plist'
+  # so this loop can do 'defaults import'. For now, emit a manual-review note.
+  echo "[Sarge] Defaults capture in \$f — manual review required (capture format is 'defaults read', not 'defaults export')."
+done
+
+# --- 5. launchctl service-state delta ---
+if [[ -s "\$BACKUP_DIR/launchctl.txt" ]]; then
+  echo "[Sarge] launchctl: comparing captured services to current state..."
+  current="\$(mktemp)"
+  launchctl list > "\$current" 2>/dev/null || true
+  # Services present at backup but not now -> load
+  # Services not at backup but now -> unload
+  # (Best-effort; some labels require a plist path or domain target.)
+  awk 'NR>1 {print \$3}' "\$BACKUP_DIR/launchctl.txt" | sort -u > "\${current}.before"
+  awk 'NR>1 {print \$3}' "\$current" | sort -u > "\${current}.after"
+  comm -23 "\${current}.before" "\${current}.after" | while read -r label; do
+    [[ -n "\$label" ]] || continue
+    sudo launchctl load -w "/Library/LaunchDaemons/\${label}.plist" 2>/dev/null || \
+      launchctl load -w "\$HOME/Library/LaunchAgents/\${label}.plist" 2>/dev/null || true
+  done
+  comm -13 "\${current}.before" "\${current}.after" | while read -r label; do
+    [[ -n "\$label" ]] || continue
+    sudo launchctl unload -w "/Library/LaunchDaemons/\${label}.plist" 2>/dev/null || \
+      launchctl unload -w "\$HOME/Library/LaunchAgents/\${label}.plist" 2>/dev/null || true
+  done
+  rm -f "\$current" "\${current}.before" "\${current}.after"
+fi
+
+echo "[Sarge] rollback.sh complete. If state is still wrong, run:"
+echo "    tmutil restore $APFS_SNAPSHOT_ID"
+ROLLBACK
+chmod +x "$ROLLBACK_SH"
+
+# -----------------------------------------------------------------------------
+# 5. Emit summary.md
+# -----------------------------------------------------------------------------
+cat > "$BACKUP_DIR/summary.md" <<EOF
+# Sarge pre-hardening backup — macOS
+
+- **Run ID:** \`$RUN_ID\`
+- **Backup dir:** \`$BACKUP_DIR\`
+- **Captured at:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- **APFS snapshot:** \`${APFS_SNAPSHOT_ID:-none}\` (status: $APFS_SNAPSHOT_STATUS)
+- **Time Machine:** $TM_STATUS
+- **Dry run:** $DRY_RUN
+
+## What was captured
+
+| Artifact | Path |
+| --- | --- |
+| APFS snapshot ID | \`apfs-snapshot.txt\` |
+| /etc tree (pam.d, sshd_config, sudoers.d, audit_*) | \`etc/\` |
+| socketfilterfw state | \`socketfilterfw.txt\` |
+| pf state (pfctl -sa) | \`pf-state.txt\` |
+| launchctl inventory | \`launchctl.txt\` |
+| defaults domains | \`defaults-*.txt\` |
+| Security posture (csrutil/spctl/fdesetup) | \`security-status.txt\` |
+
+## How to roll back
+
+Granular (file-level) rollback:
+
+\`\`\`bash
+bash "$BACKUP_DIR/rollback.sh"
+\`\`\`
+
+Heavy-lift backstop (whole boot volume):
+
+\`\`\`bash
+tmutil restore ${APFS_SNAPSHOT_ID:-<snapshot-id>}
+\`\`\`
+
+> **Untested on real macOS hardware.** See README "Pre-hardening backup + rollback (macOS)" and issue #30.
+EOF
+
+log "Backup complete."
+log "  APFS snapshot: ${APFS_SNAPSHOT_ID:-none} ($APFS_SNAPSHOT_STATUS)"
+log "  Rollback:      $ROLLBACK_SH"
+log "  Summary:       $BACKUP_DIR/summary.md"
+
+# Emit machine-readable status line for assess.sh wiring
+echo "SARGE_BACKUP_OK run_id=$RUN_ID dir=$BACKUP_DIR apfs=${APFS_SNAPSHOT_ID:-none}"

--- a/scripts/rollback-macos.sh
+++ b/scripts/rollback-macos.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# rollback-macos.sh — Sarge rollback wrapper (macOS)
+# Locates the generated per-run rollback.sh and exec's it. Mirrors the
+# Ubuntu wrapper pattern so callers don't need to know the per-run
+# folder layout.
+#
+# UNTESTED ON REAL macOS HARDWARE — see scripts/backup-macos.sh and
+# README.md "Pre-hardening backup + rollback (macOS)".
+
+set -uo pipefail
+
+UNAME_S="$(uname -s 2>/dev/null || echo unknown)"
+DRY_RUN="${SARGE_BACKUP_DRY_RUN:-0}"
+
+if [[ "$UNAME_S" != "Darwin" && "$DRY_RUN" != "1" ]]; then
+  echo "[Sarge] rollback-macos.sh: macOS only (detected: ${UNAME_S})." >&2
+  exit 2
+fi
+
+usage() {
+  cat <<EOF
+Usage: rollback-macos.sh [--run-id <id>] [--latest]
+
+Options:
+  --run-id <id>    Roll back the named run under ~/.sarge/runs/<id>/backup/
+  --latest         Roll back the most recent run found in ~/.sarge/runs/
+  -h, --help       This message
+
+Without args, --latest is assumed.
+EOF
+}
+
+RUN_ID=""
+PICK_LATEST=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)   RUN_ID="${2:-}"; PICK_LATEST=0; shift 2 ;;
+    --run-id=*) RUN_ID="${1#*=}"; PICK_LATEST=0; shift ;;
+    --latest)   PICK_LATEST=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "[Sarge] rollback-macos.sh: unknown arg '$1'" >&2; usage; exit 2 ;;
+  esac
+done
+
+RUNS_ROOT="${SARGE_RUNS_ROOT:-$HOME/.sarge/runs}"
+
+if [[ "$PICK_LATEST" == "1" ]]; then
+  if [[ ! -d "$RUNS_ROOT" ]]; then
+    echo "[Sarge] No runs found under $RUNS_ROOT" >&2
+    exit 1
+  fi
+  RUN_ID="$(ls -1t "$RUNS_ROOT" 2>/dev/null | head -n1)"
+  if [[ -z "$RUN_ID" ]]; then
+    echo "[Sarge] No runs found under $RUNS_ROOT" >&2
+    exit 1
+  fi
+fi
+
+ROLLBACK_SH="$RUNS_ROOT/$RUN_ID/backup/rollback.sh"
+if [[ ! -x "$ROLLBACK_SH" ]]; then
+  echo "[Sarge] rollback.sh not found or not executable: $ROLLBACK_SH" >&2
+  echo "[Sarge] Heavy-lift fallback: 'tmutil listlocalsnapshots /' then 'tmutil restore <id>'" >&2
+  exit 1
+fi
+
+echo "[Sarge] Executing $ROLLBACK_SH"
+exec bash "$ROLLBACK_SH"

--- a/tests/integration/backup-macos-smoke.sh
+++ b/tests/integration/backup-macos-smoke.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# backup-macos-smoke.sh — dry-run smoke test for scripts/backup-macos.sh
+#
+# This test runs on Linux (Sarge's primary dev surface). It does NOT
+# validate that the macOS-specific commands (tmutil, pfctl, defaults,
+# socketfilterfw, csrutil, spctl, fdesetup) behave correctly on a real
+# Mac — that requires hardware we don't have. It only verifies:
+#
+#   1. The script honors SARGE_BACKUP_DRY_RUN=1 on non-Darwin
+#   2. The expected artifacts are created in the per-run backup dir
+#   3. rollback.sh is emitted and is executable
+#   4. summary.md is emitted with the expected sections
+#
+# Real-Mac validation is tracked as untested in PR #30's body.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKUP_SH="$REPO_ROOT/scripts/backup-macos.sh"
+
+TMP="$(mktemp -d -t sarge-backup-macos-smoke.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+STUBS="$TMP/stubs"
+mkdir -p "$STUBS"
+
+# Stub the macOS-only binaries with no-op shims that emit something on
+# stdout so 'set -e' style consumers see a successful exit. Even though
+# the script uses SARGE_BACKUP_DRY_RUN=1 to skip executing these, having
+# stubs on PATH proves the dry-run path doesn't accidentally invoke
+# real binaries.
+for cmd in tmutil pfctl defaults csrutil spctl fdesetup launchctl diskutil; do
+  cat > "$STUBS/$cmd" <<EOF
+#!/usr/bin/env bash
+echo "[stub:$cmd] \$@"
+EOF
+  chmod +x "$STUBS/$cmd"
+done
+
+# socketfilterfw lives at /usr/libexec/ApplicationFirewall/ — the script
+# calls it via that absolute path. We don't try to stub absolute paths
+# on Linux; in dry-run mode the script doesn't invoke it anyway.
+
+RUN_ID="smoke-$(date +%s)"
+export SARGE_RUN_ROOT="$TMP/runs/$RUN_ID"
+export SARGE_BACKUP_DRY_RUN=1
+export PATH="$STUBS:$PATH"
+
+echo "[smoke] bash -n syntax check..."
+if ! bash -n "$BACKUP_SH"; then
+  echo "[smoke] FAIL: bash -n failed" >&2
+  exit 1
+fi
+echo "[smoke]   ok"
+
+echo "[smoke] bash -n rollback-macos.sh..."
+bash -n "$REPO_ROOT/scripts/rollback-macos.sh" || { echo "[smoke] FAIL: rollback-macos.sh syntax" >&2; exit 1; }
+echo "[smoke]   ok"
+
+echo "[smoke] Running backup-macos.sh --unattended --run-id $RUN_ID ..."
+if ! bash "$BACKUP_SH" --unattended --run-id "$RUN_ID" > "$TMP/stdout.log" 2> "$TMP/stderr.log"; then
+  echo "[smoke] FAIL: backup-macos.sh exited non-zero" >&2
+  echo "--- stdout ---"; cat "$TMP/stdout.log"
+  echo "--- stderr ---"; cat "$TMP/stderr.log"
+  exit 1
+fi
+
+BACKUP_DIR="$SARGE_RUN_ROOT/backup"
+
+assert_file() {
+  if [[ ! -e "$1" ]]; then
+    echo "[smoke] FAIL: expected file missing: $1" >&2
+    echo "--- backup dir tree ---"
+    find "$BACKUP_DIR" -print 2>/dev/null
+    exit 1
+  fi
+  echo "[smoke]   ok: $1"
+}
+
+echo "[smoke] Verifying expected artifacts..."
+assert_file "$BACKUP_DIR/apfs-snapshot.txt"
+assert_file "$BACKUP_DIR/socketfilterfw.txt"
+assert_file "$BACKUP_DIR/pf-state.txt"
+assert_file "$BACKUP_DIR/launchctl.txt"
+assert_file "$BACKUP_DIR/security-status.txt"
+assert_file "$BACKUP_DIR/defaults-com.apple.loginwindow.txt"
+assert_file "$BACKUP_DIR/defaults-com.apple.screensaver.txt"
+assert_file "$BACKUP_DIR/defaults-com.apple.security.txt"
+assert_file "$BACKUP_DIR/defaults-_Library_Preferences_com.apple.alf.txt"
+assert_file "$BACKUP_DIR/etc/etc/pam.d"
+assert_file "$BACKUP_DIR/etc/etc/ssh/sshd_config"
+assert_file "$BACKUP_DIR/etc/etc/sudoers.d"
+assert_file "$BACKUP_DIR/etc/etc/security/audit_control"
+assert_file "$BACKUP_DIR/rollback.sh"
+assert_file "$BACKUP_DIR/summary.md"
+
+echo "[smoke] Verifying rollback.sh is executable..."
+[[ -x "$BACKUP_DIR/rollback.sh" ]] || { echo "[smoke] FAIL: rollback.sh not executable" >&2; exit 1; }
+bash -n "$BACKUP_DIR/rollback.sh" || { echo "[smoke] FAIL: rollback.sh syntax" >&2; exit 1; }
+echo "[smoke]   ok"
+
+echo "[smoke] Verifying summary.md sections..."
+for needle in "Run ID" "APFS snapshot" "How to roll back" "tmutil restore"; do
+  if ! grep -q "$needle" "$BACKUP_DIR/summary.md"; then
+    echo "[smoke] FAIL: summary.md missing '$needle'" >&2
+    exit 1
+  fi
+done
+echo "[smoke]   ok"
+
+echo "[smoke] Verifying non-Darwin platform guard rejects without dry-run..."
+unset SARGE_BACKUP_DRY_RUN
+if bash "$BACKUP_SH" --unattended --run-id guard-test > /dev/null 2>&1; then
+  echo "[smoke] FAIL: backup-macos.sh ran on non-Darwin without dry-run flag" >&2
+  exit 1
+fi
+echo "[smoke]   ok (correctly refused)"
+
+echo "[smoke] ALL CHECKS PASSED"


### PR DESCRIPTION
## Summary

Implements the macOS pre-hardening backup + rollback per issue #30:

- `scripts/backup-macos.sh` (455 lines): APFS local snapshot via `tmutil localsnapshot` (heavy-lift backstop), optional Time Machine snapshot, file-level capture under `~/.sarge/runs/<run-id>/backup/` (/etc tree, socketfilterfw, pfctl -sa, launchctl inventory, defaults for touched domains, csrutil/spctl/fdesetup posture), emits `rollback.sh` + `summary.md`. Fails LOUDLY if the boot volume isn't APFS or local snapshots are disabled — no silent proceed.
- `scripts/rollback-macos.sh` (68 lines): wrapper that auto-locates the per-run `rollback.sh`, mirrors the Ubuntu pattern.
- `tests/integration/backup-macos-smoke.sh` (120 lines): Linux dry-run smoke test (the script honors `SARGE_BACKUP_DRY_RUN=1` and exits with a clear `macOS only` message otherwise).
- README section "Pre-hardening backup + rollback (macOS)" documenting the model and explicitly flagging the entire macOS implementation as untested.

Honors `~/.sarge/runs/<run-id>/backup/` per-run folder layout from PR #42. Accepts `--unattended`, `--run-id <id>`, `--time-machine`.

## Untested on real macOS hardware

**The entire macOS implementation has NOT been exercised against a real Mac.** Oscar Six does not currently have a macOS test surface available. The implementation follows the issue spec and the Ubuntu/Windows backup patterns, but the macOS-specific binaries — `tmutil`, `pfctl`, `defaults`, `socketfilterfw`, `csrutil`, `spctl`, `fdesetup`, `launchctl`, `diskutil` — have **not** been validated against live binaries.

Only validation performed:

- `bash -n` syntax check on all three scripts (passed)
- Linux dry-run smoke test (`tests/integration/backup-macos-smoke.sh`) verifies expected files would be written and the non-Darwin platform guard rejects without `SARGE_BACKUP_DRY_RUN=1` (passed)

**Validation contribution welcome.** Open a PR or comment on issue #30 with results from a real Mac. Known places that need real-hardware shake-out:

- `tmutil localsnapshot` output parsing — assumes `Created local snapshot with date: <id>` format
- `diskutil info /` File-System-Personality regex for APFS detection
- `pfctl -sa` round-trip through `pfctl -f` (the captured format is human-readable; rollback is best-effort)
- `defaults read` capture is not directly importable; rollback emits a manual-review note (Phase 2 should switch to `defaults export`)
- `socketfilterfw` per-app rule replay (no native bulk-import)
- `launchctl list` -> `launchctl load/unload` delta logic

## Test plan

- [x] `bash -n scripts/backup-macos.sh`
- [x] `bash -n scripts/rollback-macos.sh`
- [x] `bash tests/integration/backup-macos-smoke.sh` (dry-run on Linux) — ALL CHECKS PASSED
- [ ] **(needs real Mac)** Run `scripts/backup-macos.sh --unattended` on a live macOS host with APFS root; verify `tmutil listlocalsnapshots /` shows the snapshot
- [ ] **(needs real Mac)** Roll back via `scripts/rollback-macos.sh --latest`; verify /etc tree restored
- [ ] **(needs real Mac)** Roll back via `tmutil restore <id>` heavy-lift fallback

Closes #30.

**Untested on real macOS hardware** — implementation follows the issue spec and the Ubuntu pattern but has not been exercised against an actual Mac. Validation contribution welcome.

Generated with Claude Code