### PR TITLE
fix(windows-rollback): flatten ConvertFrom-Json array correctly under PS 5.1

### DIFF
--- a/scripts/rollback-windows.ps1
+++ b/scripts/rollback-windows.ps1
@@ -143,7 +143,17 @@ if (Test-Path -LiteralPath $taskDir) {
     $entries = @()
     if (Test-Path -LiteralPath $manifestFile) {
         try {
-            $entries = @(Get-Content -Raw -LiteralPath $manifestFile | ConvertFrom-Json)
+            # ConvertFrom-Json returns Object[] for a top-level JSON array.
+            # Wrapping that with @(...) does NOT flatten under PS 5.1 —
+            # @(@(...)) yields a single-element wrapper, so $entries.Count
+            # would be 1 and the foreach would iterate once with $entry
+            # bound to the whole inner array (and $entry.taskName $null).
+            # Build the list explicitly so both array-of-N and single-object
+            # payloads land as N PSObject entries.
+            $parsed = Get-Content -Raw -LiteralPath $manifestFile | ConvertFrom-Json
+            if ($null -ne $parsed) {
+                foreach ($e in $parsed) { $entries += ,$e }
+            }
         } catch {
             Write-Warning "tasks/manifest.json unreadable ($($_.Exception.Message)); falling back to filename scan"
         }


### PR DESCRIPTION
Found while validating PR #47 end-to-end on RH2. Symptom: rollback silently skipped every captured task because PS 5.1's @(... | ConvertFrom-Json) doesn't flatten when ConvertFrom-Json returns Object[]. `$entries.Count` was 1 (a wrapper around the inner array), the foreach iterated once with `$entry` bound to the whole array, `$entry.taskName` was `$null`, the existence check no-op'd, every task got skipped. Fix builds the entries list explicitly via foreach + comma-prefixed expression. RH2 validation: install task at \\Sarge-Test\\T → backup → delete → rollback → task restored at original path.