### PR TITLE
feat: --host-only mode to scan without agent-runtime overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ sudo ./scripts/install.sh
 
 Full docs: [docs/quickstart.md](docs/quickstart.md)
 
+### Scan Modes
+
+By default, Sarge runs in **agent-host** mode — it emits both the generic NIST 800-53 host findings AND the OpenClaw agent-runtime-specific findings (workspace ACL, secrets-dir perms, gateway TLS, etc.).
+
+For hosts that don't run AI agents, or when you want a clean compliance baseline without agent-runtime context, pass `--host-only`:
+
+```bash
+# Host-only mode — pure baseline scan, no agent-overlay findings
+./assessment/assess.sh --host-only
+
+# Windows
+pwsh assessment/assess.ps1 --host-only
+```
+
+In host-only mode, agent-scoped findings are excluded entirely (not even SKIP — they're out of scope). The report header states which mode the run used. See [#50](https://github.com/oscarsixsecllc/sarge/issues/50) for details.
+
 ---
 
 ## Control Coverage (v0.1.1)

--- a/assessment/assess.ps1
+++ b/assessment/assess.ps1
@@ -24,6 +24,7 @@ $ShowVersion    = $false
 $ChecksOnly     = $false
 $ReportOnly     = $false
 $InspectPolicy  = $false
+$HostOnly       = $false
 foreach ($arg in @($RemainingArgs)) {
     if ([string]::IsNullOrWhiteSpace($arg)) { continue }
     switch ($arg) {
@@ -34,6 +35,7 @@ foreach ($arg in @($RemainingArgs)) {
         '--checks-only'      { $ChecksOnly = $true }
         '--report-only'      { $ReportOnly = $true }
         '--inspect-policy'   { $InspectPolicy = $true }
+        '--host-only'        { $HostOnly = $true }
         default              { Write-Warning "Unknown argument ignored: $arg" }
     }
 }
@@ -57,6 +59,9 @@ OPTIONS
                       verdicts onto Phase 1a control findings where managed
                       policy provides the enforcement. Standard user, no
                       elevation. See issue #31.
+    --host-only       Skip agent-runtime-specific findings (OpenClaw
+                      workspace checks). Use for pure baseline scanning on
+                      hosts that don't run AI agents. See issue #50.
 
 SCOPE
     Detection + breadth-first checks across all six 800-53 families on
@@ -94,12 +99,16 @@ foreach ($p in 'windows-ac','windows-au','windows-cm','windows-ia','windows-sc',
     . $path
 }
 
+$script:SargeHostOnly = [bool]$HostOnly
+$script:SargeMode = if ($HostOnly) { 'host-only' } else { 'agent-host' }
+
 $phaseTag = if ($InspectPolicy) { 'Phase 1a + 1b (policy overlay)' } else { 'Phase 1a' }
 Write-Output "[SARGE] ======================================"
 Write-Output ("[SARGE]  Sarge - Windows assessment ({0})" -f $phaseTag)
 Write-Output "[SARGE]  Oscar Six Security LLC"
 Write-Output "[SARGE]  $(Get-Date)"
 Write-Output "[SARGE]  Host: $env:COMPUTERNAME"
+Write-Output ("[SARGE]  Mode: {0}" -f $script:SargeMode)
 Write-Output "[SARGE] ======================================"
 Write-Output ""
 

--- a/assessment/assess.sh
+++ b/assessment/assess.sh
@@ -5,6 +5,14 @@
 
 set -uo pipefail
 
+SARGE_HOST_ONLY="${SARGE_HOST_ONLY:-0}"
+for arg in "$@"; do
+  case "$arg" in
+    --host-only) SARGE_HOST_ONLY=1 ;;
+  esac
+done
+export SARGE_HOST_ONLY
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -86,12 +94,17 @@ skipx() { local id="$1"; shift; echo "  [SKIP] $*"; SKIP=$((SKIP+1)); RESULTS+=(
 export -f pass warn fail skip passx warnx failx skipx
 export PASS WARN FAIL SKIP
 
+SARGE_MODE="agent-host"
+[[ "$SARGE_HOST_ONLY" == "1" ]] && SARGE_MODE="host-only"
+export SARGE_MODE
+
 log "======================================"
 log " Sarge NIST 800-53 Gap Analysis"
 log " Oscar Six Security LLC"
 log " $(date)"
 log " Host: $(hostname)"
 log " OS: ${SARGE_OS_DESCRIPTION}"
+log " Mode: ${SARGE_MODE}"
 log "======================================"
 echo ""
 
@@ -119,6 +132,7 @@ log "======================================"
   --state-dir "$STATE_DIR" \
   --run-root "$SARGE_RUN_ROOT" \
   --run-id "$SARGE_RUN_ID" \
+  --mode "$SARGE_MODE" \
   --catalog "$SCRIPT_DIR/findings-catalog.json" \
   --results "$(printf '%s\n' "${RESULTS[@]}")" || true
 

--- a/assessment/checks/check-ac.sh
+++ b/assessment/checks/check-ac.sh
@@ -20,38 +20,40 @@ else
 fi
 
 # AC-3: Access Enforcement — filesystem permissions on OpenClaw workspace
-log "AC-3: Access Enforcement"
-OC_DIR="$HOME/.openclaw"
-if [[ -d "$OC_DIR" ]]; then
-  OC_PERM=$(platform file_perm "$OC_DIR")
-  if [[ "$OC_PERM" == "700" ]]; then
-    passx "AC-3-openclaw-dir-perm" "AC-3: ~/.openclaw permissions are 700"
-  else
-    failx "AC-3-openclaw-dir-perm" "AC-3: ~/.openclaw permissions are $OC_PERM — should be 700"
-  fi
-
-  SECRETS_DIR="$OC_DIR/secrets"
-  if [[ -d "$SECRETS_DIR" ]]; then
-    S_PERM=$(platform file_perm "$SECRETS_DIR")
-    if [[ "$S_PERM" == "700" ]]; then
-      passx "AC-3-secrets-dir-perm" "AC-3: ~/.openclaw/secrets permissions are 700"
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  log "AC-3: Access Enforcement"
+  OC_DIR="$HOME/.openclaw"
+  if [[ -d "$OC_DIR" ]]; then
+    OC_PERM=$(platform file_perm "$OC_DIR")
+    if [[ "$OC_PERM" == "700" ]]; then
+      passx "AC-3-openclaw-dir-perm" "AC-3: ~/.openclaw permissions are 700"
     else
-      failx "AC-3-secrets-dir-perm" "AC-3: ~/.openclaw/secrets permissions are $S_PERM — should be 700"
+      failx "AC-3-openclaw-dir-perm" "AC-3: ~/.openclaw permissions are $OC_PERM — should be 700"
     fi
 
-    while IFS= read -r -d '' f; do
-      F_PERM=$(platform file_perm "$f")
-      if [[ "$F_PERM" == "600" ]]; then
-        passx "AC-3-secret-file-perm" "AC-3: Secret file $f is 600"
+    SECRETS_DIR="$OC_DIR/secrets"
+    if [[ -d "$SECRETS_DIR" ]]; then
+      S_PERM=$(platform file_perm "$SECRETS_DIR")
+      if [[ "$S_PERM" == "700" ]]; then
+        passx "AC-3-secrets-dir-perm" "AC-3: ~/.openclaw/secrets permissions are 700"
       else
-        failx "AC-3-secret-file-perm" "AC-3: Secret file $f is $F_PERM — should be 600"
+        failx "AC-3-secrets-dir-perm" "AC-3: ~/.openclaw/secrets permissions are $S_PERM — should be 700"
       fi
-    done < <(find "$SECRETS_DIR" -maxdepth 1 -type f -print0 2>/dev/null)
+
+      while IFS= read -r -d '' f; do
+        F_PERM=$(platform file_perm "$f")
+        if [[ "$F_PERM" == "600" ]]; then
+          passx "AC-3-secret-file-perm" "AC-3: Secret file $f is 600"
+        else
+          failx "AC-3-secret-file-perm" "AC-3: Secret file $f is $F_PERM — should be 600"
+        fi
+      done < <(find "$SECRETS_DIR" -maxdepth 1 -type f -print0 2>/dev/null)
+    else
+      skipx "AC-3-secrets-dir-perm" "AC-3: No secrets directory found at $SECRETS_DIR"
+    fi
   else
-    skipx "AC-3-secrets-dir-perm" "AC-3: No secrets directory found at $SECRETS_DIR"
+    skipx "AC-3-openclaw-dir-perm" "AC-3: No ~/.openclaw directory found"
   fi
-else
-  skipx "AC-3-openclaw-dir-perm" "AC-3: No ~/.openclaw directory found"
 fi
 
 # AC-6: Least Privilege — sudo configuration

--- a/assessment/checks/check-au.sh
+++ b/assessment/checks/check-au.sh
@@ -12,17 +12,21 @@ else
   failx "AU-2-auditd-not-running" "AU-2: audit daemon is not running — install and enable: sudo apt install auditd"
 fi
 
-# AU-12: Audit rules covering OpenClaw secrets
+# AU-12: Audit rules
 log "AU-12: Audit rules"
 if ! platform_supports auditctl_available; then
-  skipx "AU-12-no-openclaw-rules" "AU-12: per-file audit rules are a Linux auditd construct; not applicable on ${SARGE_OS_DESCRIPTION}"
+  if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+    skipx "AU-12-no-openclaw-rules" "AU-12: per-file audit rules are a Linux auditd construct; not applicable on ${SARGE_OS_DESCRIPTION}"
+  fi
 elif platform auditctl_available; then
   AUDIT_RULES=$(platform audit_rules)
-  OC_SECRETS="$HOME/.openclaw/secrets"
-  if echo "$AUDIT_RULES" | grep -q "openclaw\|$OC_SECRETS"; then
-    passx "AU-12-no-openclaw-rules" "AU-12: Audit rules cover OpenClaw secrets directory"
-  else
-    failx "AU-12-no-openclaw-rules" "AU-12: No audit rules found for OpenClaw secrets — run harden-auditd.sh"
+  if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+    OC_SECRETS="$HOME/.openclaw/secrets"
+    if echo "$AUDIT_RULES" | grep -q "openclaw\|$OC_SECRETS"; then
+      passx "AU-12-no-openclaw-rules" "AU-12: Audit rules cover OpenClaw secrets directory"
+    else
+      failx "AU-12-no-openclaw-rules" "AU-12: No audit rules found for OpenClaw secrets — run harden-auditd.sh"
+    fi
   fi
   if echo "$AUDIT_RULES" | grep -q "passwd\|shadow\|sudoers"; then
     passx "AU-12-no-auth-rules" "AU-12: Audit rules cover auth-critical files"
@@ -30,7 +34,9 @@ elif platform auditctl_available; then
     warnx "AU-12-no-auth-rules" "AU-12: No audit rules for /etc/passwd, /etc/shadow, or /etc/sudoers"
   fi
 else
-  skipx "AU-12-no-openclaw-rules" "AU-12: audit rule inspection tool not available"
+  if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+    skipx "AU-12-no-openclaw-rules" "AU-12: audit rule inspection tool not available"
+  fi
 fi
 
 # AU-3 / AU-9: Audit log protection

--- a/assessment/checks/check-sc.sh
+++ b/assessment/checks/check-sc.sh
@@ -2,50 +2,51 @@
 # check-sc.sh — System & Communications Protection (SC) — partial — NIST 800-53 Rev 5
 # Platform-specific data acquisition lives in lib/platforms/<os>.sh.
 
-# SC-8: Transmission Confidentiality — check for TLS on gateway port
-log "SC-8: Transmission confidentiality"
-GW_PORT="${OPENCLAW_GATEWAY_PORT:-18790}"
-if platform port_listening "$GW_PORT"; then
-  passx "SC-8-cloudflared-not-detected" "SC-8: OpenClaw gateway is listening on port $GW_PORT"
-  # Check if Cloudflare tunnel is the access path (preferred over direct TLS)
-  if pgrep -x "cloudflared" &>/dev/null; then
-    passx "SC-8-cloudflared-not-detected" "SC-8: cloudflared is running — Cloudflare Tunnel provides TLS termination"
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  # SC-8: Transmission Confidentiality — check for TLS on gateway port
+  log "SC-8: Transmission confidentiality"
+  GW_PORT="${OPENCLAW_GATEWAY_PORT:-18790}"
+  if platform port_listening "$GW_PORT"; then
+    passx "SC-8-cloudflared-not-detected" "SC-8: OpenClaw gateway is listening on port $GW_PORT"
+    if pgrep -x "cloudflared" &>/dev/null; then
+      passx "SC-8-cloudflared-not-detected" "SC-8: cloudflared is running — Cloudflare Tunnel provides TLS termination"
+    else
+      warnx "SC-8-cloudflared-not-detected" "SC-8: cloudflared not detected — verify TLS is configured on gateway directly"
+    fi
   else
-    warnx "SC-8-cloudflared-not-detected" "SC-8: cloudflared not detected — verify TLS is configured on gateway directly"
+    skipx "SC-8-cloudflared-not-detected" "SC-8: OpenClaw gateway port $GW_PORT not detected — may be using different port"
   fi
-else
-  skipx "SC-8-cloudflared-not-detected" "SC-8: OpenClaw gateway port $GW_PORT not detected — may be using different port"
-fi
 
-# SC-28: Protection at rest — OpenClaw config permissions
-log "SC-28: Protection of information at rest"
-OC_CONFIG="$HOME/.openclaw/config.json"
-if [[ -f "$OC_CONFIG" ]]; then
-  CONFIG_PERM=$(platform file_perm "$OC_CONFIG")
-  CONFIG_OWNER=$(platform file_owner "$OC_CONFIG")
-  if [[ "$CONFIG_PERM" == "600" || "$CONFIG_PERM" == "400" ]]; then
-    passx "SC-28-config-perm" "SC-28: OpenClaw config.json is $CONFIG_PERM (restricted)"
+  # SC-28: Protection at rest — OpenClaw config permissions
+  log "SC-28: Protection of information at rest"
+  OC_CONFIG="$HOME/.openclaw/config.json"
+  if [[ -f "$OC_CONFIG" ]]; then
+    CONFIG_PERM=$(platform file_perm "$OC_CONFIG")
+    CONFIG_OWNER=$(platform file_owner "$OC_CONFIG")
+    if [[ "$CONFIG_PERM" == "600" || "$CONFIG_PERM" == "400" ]]; then
+      passx "SC-28-config-perm" "SC-28: OpenClaw config.json is $CONFIG_PERM (restricted)"
+    else
+      failx "SC-28-config-perm" "SC-28: OpenClaw config.json is $CONFIG_PERM — should be 600"
+    fi
+    CURRENT_USER=$(whoami)
+    if [[ "$CONFIG_OWNER" == "$CURRENT_USER" ]]; then
+      passx "SC-28-config-owner" "SC-28: config.json owned by current service user ($CURRENT_USER)"
+    else
+      warnx "SC-28-config-owner" "SC-28: config.json owned by $CONFIG_OWNER — expected $CURRENT_USER"
+    fi
   else
-    failx "SC-28-config-perm" "SC-28: OpenClaw config.json is $CONFIG_PERM — should be 600"
+    skipx "SC-28-config-perm" "SC-28: OpenClaw config.json not found at $OC_CONFIG"
   fi
-  CURRENT_USER=$(whoami)
-  if [[ "$CONFIG_OWNER" == "$CURRENT_USER" ]]; then
-    passx "SC-28-config-owner" "SC-28: config.json owned by current service user ($CURRENT_USER)"
-  else
-    warnx "SC-28-config-owner" "SC-28: config.json owned by $CONFIG_OWNER — expected $CURRENT_USER"
-  fi
-else
-  skipx "SC-28-config-perm" "SC-28: OpenClaw config.json not found at $OC_CONFIG"
-fi
 
-# SC-28: Check for world-readable sensitive files
-log "SC-28: World-readable sensitive files"
-OC_DIR="$HOME/.openclaw"
-if [[ -d "$OC_DIR" ]]; then
-  WORLD_READABLE=$(platform world_readable_files_in "$OC_DIR")
-  if [[ -z "$WORLD_READABLE" ]]; then
-    passx "SC-28-world-readable-secrets" "SC-28: No world-readable files in ~/.openclaw"
-  else
-    failx "SC-28-world-readable-secrets" "SC-28: World-readable files found in ~/.openclaw: $(echo "$WORLD_READABLE" | tr '\n' ' ')"
+  # SC-28: Check for world-readable sensitive files
+  log "SC-28: World-readable sensitive files"
+  OC_DIR="$HOME/.openclaw"
+  if [[ -d "$OC_DIR" ]]; then
+    WORLD_READABLE=$(platform world_readable_files_in "$OC_DIR")
+    if [[ -z "$WORLD_READABLE" ]]; then
+      passx "SC-28-world-readable-secrets" "SC-28: No world-readable files in ~/.openclaw"
+    else
+      failx "SC-28-world-readable-secrets" "SC-28: World-readable files found in ~/.openclaw: $(echo "$WORLD_READABLE" | tr '\n' ' ')"
+    fi
   fi
 fi

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -7,7 +7,8 @@
       "what": "Short description of the observed condition. Templates may include shell-style placeholders like {value} that report.sh leaves as-is — the finding 'description' from the check script is what actually appears in reports; this 'what' is reference-only.",
       "expected": "What the value/state should be.",
       "why": "2-3 sentences explaining the security risk. References the NIST 800-53 Rev 5 control by name.",
-      "fix": "Runnable command or one-line action."
+      "fix": "Runnable command or one-line action.",
+      "scope": "\"host\" (default) or \"agent\" — agent-scoped findings probe the OpenClaw / agent-runtime overlay and are excluded in --host-only mode."
     },
     "coverage": "Every fail \"...\" and warn \"...\" callsite in assessment/checks/check-*.sh. PASS/SKIP do not need entries."
   },
@@ -30,21 +31,24 @@
     "what": "~/.openclaw directory permissions are not 700",
     "expected": "700 (owner-only)",
     "why": "The ~/.openclaw directory holds workspace state, agent memory, and credential paths used by OpenClaw subprocesses. NIST 800-53 AC-3 requires enforcement of approved access — group/world-readable workspace directories let other local users enumerate which agents and accounts the operator runs. Even read access leaks operational intent.",
-    "fix": "chmod 700 ~/.openclaw"
+    "fix": "chmod 700 ~/.openclaw",
+    "scope": "agent"
   },
   "AC-3-secrets-dir-perm": {
     "family": "AC-3 — Access Enforcement",
     "what": "~/.openclaw/secrets directory permissions are not 700",
     "expected": "700 (owner-only)",
     "why": "Group/world-readable secrets directory exposes OAuth tokens and API keys cached by OpenClaw to other local users or processes. NIST 800-53 AC-3 requires access enforcement that limits sensitive resources to authorized identities. Any unprivileged local process — including a compromised browser or editor — can read tokens and impersonate the operator against external services.",
-    "fix": "chmod 700 ~/.openclaw/secrets"
+    "fix": "chmod 700 ~/.openclaw/secrets",
+    "scope": "agent"
   },
   "AC-3-secret-file-perm": {
     "family": "AC-3 — Access Enforcement",
     "what": "Individual secret file under ~/.openclaw/secrets is not 600",
     "expected": "600 (owner read/write only)",
     "why": "Even if the parent directory is locked down, lax file modes on individual tokens allow exfiltration via backup, sync, or container bind-mount. NIST 800-53 AC-3 requires per-resource access enforcement, not just directory-level. A 644 token survives a tarball or rsync that preserves modes but loses parent-dir context.",
-    "fix": "chmod 600 ~/.openclaw/secrets/<file>"
+    "fix": "chmod 600 ~/.openclaw/secrets/<file>",
+    "scope": "agent"
   },
   "AC-6-passwordless-sudo": {
     "family": "AC-6 — Least Privilege",
@@ -128,7 +132,8 @@
     "what": "No audit rules cover ~/.openclaw/secrets",
     "expected": "auditctl -l shows watch rules for the secrets directory",
     "why": "Without watch rules, reads/writes to high-value secret material are not recorded. NIST 800-53 AU-12 requires that audit records be generated for defined auditable events — for sarge's threat model, OpenClaw secret access is one of those events. Detecting credential exfiltration after the fact requires this trail.",
-    "fix": "Run: scripts/harden-auditd.sh  # or add: sudo auditctl -w ~/.openclaw/secrets -p rwxa -k openclaw-secrets"
+    "fix": "Run: scripts/harden-auditd.sh  # or add: sudo auditctl -w ~/.openclaw/secrets -p rwxa -k openclaw-secrets",
+    "scope": "agent"
   },
   "AU-12-no-auth-rules": {
     "family": "AU-12 — Audit Generation",
@@ -282,28 +287,32 @@
     "what": "OpenClaw gateway is listening but cloudflared is not running",
     "expected": "cloudflared running (Cloudflare Tunnel TLS termination) or TLS configured directly on the gateway",
     "why": "Without TLS termination, gateway traffic is unencrypted on the wire, exposing tokens and agent payloads. NIST 800-53 SC-8 requires confidentiality of transmitted information. The OpenClaw deployment pattern relies on Cloudflare Tunnel for TLS; if cloudflared isn't running, either the tunnel is down or the gateway is exposed without TLS.",
-    "fix": "sudo systemctl start cloudflared  # or: cloudflared tunnel run <tunnel-name>  # if direct access intended, configure TLS on the gateway and document"
+    "fix": "sudo systemctl start cloudflared  # or: cloudflared tunnel run <tunnel-name>  # if direct access intended, configure TLS on the gateway and document",
+    "scope": "agent"
   },
   "SC-28-config-perm": {
     "family": "SC-28 — Protection of Information at Rest",
     "what": "~/.openclaw/config.json permissions are not 600 or 400",
     "expected": "600 (or 400 if read-only is sufficient)",
     "why": "config.json holds connection details and possibly inline credentials for the OpenClaw runtime. NIST 800-53 SC-28 requires protection of information at rest. World/group-readable config gives any local process a roadmap of services and their auth material.",
-    "fix": "chmod 600 ~/.openclaw/config.json"
+    "fix": "chmod 600 ~/.openclaw/config.json",
+    "scope": "agent"
   },
   "SC-28-config-owner": {
     "family": "SC-28 — Protection of Information at Rest",
     "what": "~/.openclaw/config.json is owned by an unexpected user",
     "expected": "Owned by the current operator/service user",
     "why": "Wrong ownership often means the file was created by a different account (root via sudo, an installer, or a previous user) and may have unexpected permission semantics. NIST 800-53 SC-28 + AC-3 require explicit ownership of sensitive resources. Sort out who is supposed to own the config and align permissions.",
-    "fix": "sudo chown $(whoami):$(whoami) ~/.openclaw/config.json"
+    "fix": "sudo chown $(whoami):$(whoami) ~/.openclaw/config.json",
+    "scope": "agent"
   },
   "SC-28-world-readable-secrets": {
     "family": "SC-28 — Protection of Information at Rest",
     "what": "World-readable files found inside ~/.openclaw",
     "expected": "No files in ~/.openclaw are world-readable (mode bit o+r unset)",
     "why": "World-readable files in the OpenClaw workspace expose agent state, memory snippets, and potentially cached credentials to any local user. NIST 800-53 SC-28 requires confidentiality at rest. Even non-secret workspace files can leak operational intelligence (agent names, schedules, target hostnames).",
-    "fix": "chmod -R o-r ~/.openclaw  # then re-verify with: find ~/.openclaw -type f -perm /004"
+    "fix": "chmod -R o-r ~/.openclaw  # then re-verify with: find ~/.openclaw -type f -perm /004",
+    "scope": "agent"
   },
   "SI-2-security-updates-low": {
     "family": "SI-2 — Flaw Remediation",

--- a/assessment/report/report.sh
+++ b/assessment/report/report.sh
@@ -14,6 +14,7 @@ STATE_DIR=""
 RUN_ROOT=""
 RUN_ID=""
 CATALOG=""
+SARGE_MODE="agent-host"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -28,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --run-root) RUN_ROOT="$2"; shift 2 ;;
     --run-id) RUN_ID="$2"; shift 2 ;;
     --catalog) CATALOG="$2"; shift 2 ;;
+    --mode) SARGE_MODE="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
@@ -252,6 +254,10 @@ INSTALL_DATE_HUMAN="$INSTALLED_AT"
   echo "> Drifts caught on this host since first install (${INSTALL_DATE_HUMAN}): **${DRIFT_COUNT}**"
   echo ""
   echo "**OS:** ${OS}"
+  if [[ "$SARGE_MODE" == "host-only" ]]; then
+    echo ""
+    echo "**Mode:** host-only (agent-runtime checks excluded)"
+  fi
   echo ""
   echo "## Summary"
   echo ""
@@ -326,6 +332,7 @@ if command -v jq &>/dev/null; then
     --arg date "$TIMESTAMP" \
     --arg host "$HOST" \
     --arg os "$OS" \
+    --arg mode "$SARGE_MODE" \
     --arg installed "$INSTALLED_AT" \
     --argjson drift "$DRIFT_COUNT" \
     --argjson total "$TOTAL" \
@@ -345,6 +352,7 @@ if command -v jq &>/dev/null; then
       assessment_date: $date,
       host: $host,
       os: $os,
+      mode: $mode,
       installedAt: $installed,
       driftCount: $drift,
       summary: {
@@ -371,6 +379,7 @@ else
     echo "  \"assessment_date\": \"${TIMESTAMP}\","
     echo "  \"host\": \"${HOST}\","
     echo "  \"os\": \"${OS}\","
+    echo "  \"mode\": \"${SARGE_MODE}\","
     echo "  \"installedAt\": \"${INSTALLED_AT}\","
     echo "  \"driftCount\": ${DRIFT_COUNT},"
     echo "  \"summary\": {"

--- a/tests/Pester/windows-host-only.Tests.ps1
+++ b/tests/Pester/windows-host-only.Tests.ps1
@@ -1,0 +1,67 @@
+# tests/Pester/windows-host-only.Tests.ps1 - Pester tests for --host-only flag.
+#
+# Validates that assess.ps1 accepts the --host-only flag and sets the
+# expected script-scope variables. No agent-specific Windows checks exist
+# yet, so this primarily tests flag parsing and mode header output.
+
+Describe '--host-only flag parsing' {
+    BeforeAll {
+        $repoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+        $assessScript = Join-Path $repoRoot 'assessment\assess.ps1'
+    }
+
+    It 'assess.ps1 contains --host-only in argument switch' {
+        $content = Get-Content -Path $assessScript -Raw
+        $content | Should -Match '--host-only'
+    }
+
+    It 'assess.ps1 help text documents --host-only' {
+        $content = Get-Content -Path $assessScript -Raw
+        $content | Should -Match 'host-only.*agent-runtime'
+    }
+
+    It 'assess.ps1 sets SargeMode to host-only when flag is present' {
+        $content = Get-Content -Path $assessScript -Raw
+        $content | Should -Match "SargeMode.*host-only"
+    }
+
+    It 'assess.ps1 sets SargeMode to agent-host by default' {
+        $content = Get-Content -Path $assessScript -Raw
+        $content | Should -Match "SargeMode.*agent-host"
+    }
+}
+
+Describe 'findings-catalog.json scope field' {
+    BeforeAll {
+        $repoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+        $catalogPath = Join-Path $repoRoot 'assessment\findings-catalog.json'
+        $catalog = Get-Content -Path $catalogPath -Raw | ConvertFrom-Json
+    }
+
+    It 'schema documents the scope field' {
+        $catalog._doc.schema.scope | Should -Not -BeNullOrEmpty
+    }
+
+    It 'agent-scoped entries have scope=agent' {
+        $agentIds = @(
+            'AC-3-openclaw-dir-perm',
+            'AC-3-secrets-dir-perm',
+            'AC-3-secret-file-perm',
+            'AU-12-no-openclaw-rules',
+            'SC-8-cloudflared-not-detected',
+            'SC-28-config-perm',
+            'SC-28-config-owner',
+            'SC-28-world-readable-secrets'
+        )
+        foreach ($id in $agentIds) {
+            $catalog.$id.scope | Should -Be 'agent' -Because "$id should be scope:agent"
+        }
+    }
+
+    It 'host-scoped entries do not have a scope field' {
+        $hostIds = @('AC-2-empty-password', 'AC-6-passwordless-sudo', 'AU-2-auditd-not-running')
+        foreach ($id in $hostIds) {
+            $catalog.$id.PSObject.Properties.Name | Should -Not -Contain 'scope' -Because "$id is host-scope (implicit)"
+        }
+    }
+}

--- a/tests/integration/host-only-mode.sh
+++ b/tests/integration/host-only-mode.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# tests/integration/host-only-mode.sh
+# Validates --host-only mode: catalog scope tags, guard coverage, syntax.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CATALOG="$REPO_ROOT/assessment/findings-catalog.json"
+
+PASS=0; TESTS=0
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { PASS=$((PASS+1)); TESTS=$((TESTS+1)); echo "  ok: $*"; }
+
+# --- Syntax checks ---
+bash -n "$REPO_ROOT/assessment/assess.sh" || fail "assess.sh syntax error"
+ok "assess.sh syntax"
+
+for f in "$REPO_ROOT"/assessment/checks/check-*.sh; do
+  bash -n "$f" || fail "$(basename "$f") syntax error"
+done
+ok "all check-*.sh syntax"
+
+# --- Catalog scope tags ---
+AGENT_IDS=(
+  AC-3-openclaw-dir-perm
+  AC-3-secrets-dir-perm
+  AC-3-secret-file-perm
+  AU-12-no-openclaw-rules
+  SC-8-cloudflared-not-detected
+  SC-28-config-perm
+  SC-28-config-owner
+  SC-28-world-readable-secrets
+)
+
+for id in "${AGENT_IDS[@]}"; do
+  scope=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+e=d.get(sys.argv[2],{})
+print(e.get('scope',''))
+" "$CATALOG" "$id" 2>/dev/null)
+  [[ "$scope" == "agent" ]] || fail "catalog entry $id missing scope:agent (got '$scope')"
+done
+ok "all agent findings have scope:agent in catalog"
+
+HOST_IDS=(AC-2-empty-password AC-6-passwordless-sudo AU-2-auditd-not-running CM-2-no-baseline)
+for id in "${HOST_IDS[@]}"; do
+  scope=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+e=d.get(sys.argv[2],{})
+print(e.get('scope',''))
+" "$CATALOG" "$id" 2>/dev/null)
+  [[ "$scope" == "" ]] || fail "host-scope entry $id should NOT have scope field (got '$scope')"
+done
+ok "host findings have no scope tag (implicit host)"
+
+# --- Guard coverage: agent blocks are wrapped in SARGE_HOST_ONLY checks ---
+# Verify that every agent check ID appears inside a SARGE_HOST_ONLY guarded
+# block. We check that the guard line appears before the first use of the ID.
+for id in "${AGENT_IDS[@]}"; do
+  found=0
+  for check_file in "$REPO_ROOT"/assessment/checks/check-*.sh; do
+    if grep -q "$id" "$check_file" 2>/dev/null; then
+      found=1
+      guard_line=$(grep -n 'SARGE_HOST_ONLY' "$check_file" | head -1 | cut -d: -f1)
+      id_line=$(grep -n "$id" "$check_file" | head -1 | cut -d: -f1)
+      [[ -n "$guard_line" && -n "$id_line" && "$guard_line" -lt "$id_line" ]] \
+        || fail "$id in $(basename "$check_file") is not guarded by SARGE_HOST_ONLY"
+    fi
+  done
+  [[ "$found" -eq 1 ]] || fail "$id not found in any check file"
+done
+ok "all agent check IDs are guarded by SARGE_HOST_ONLY"
+
+# --- assess.sh accepts --host-only without error ---
+grep -q '\-\-host-only' "$REPO_ROOT/assessment/assess.sh" || fail "assess.sh doesn't parse --host-only"
+ok "assess.sh parses --host-only flag"
+
+# --- report.sh accepts --mode ---
+grep -q '\-\-mode' "$REPO_ROOT/assessment/report/report.sh" || fail "report.sh doesn't parse --mode"
+ok "report.sh parses --mode parameter"
+
+echo ""
+echo "host-only-mode: $PASS/$TESTS passed"
+[[ "$PASS" -eq "$TESTS" ]]


### PR DESCRIPTION
## Summary

Implements `--host-only` flag for both bash and PowerShell entrypoints, allowing Sarge to run as a pure NIST 800-53 baseline scanner without the OpenClaw agent-runtime overlay.

- **Flag:** `--host-only` on `assess.sh` and `assess.ps1` (also via `SARGE_HOST_ONLY=1` env var)
- **Catalog:** 8 agent-scoped findings tagged with `"scope": "agent"` in `findings-catalog.json`
- **Behavior:** Agent-scoped checks are completely excluded in host-only mode (no PASS/FAIL/SKIP emitted)
- **Report:** Header and JSON output include the mode (`agent-host` or `host-only`)
- **Tests:** Bash integration test (7 assertions) + Pester structural tests
- **Docs:** README updated with scan modes section

## Agent-scoped findings gated

| Check ID | File | Family |
|----------|------|--------|
| `AC-3-openclaw-dir-perm` | check-ac.sh | AC-3 |
| `AC-3-secrets-dir-perm` | check-ac.sh | AC-3 |
| `AC-3-secret-file-perm` | check-ac.sh | AC-3 |
| `AU-12-no-openclaw-rules` | check-au.sh | AU-12 |
| `SC-8-cloudflared-not-detected` | check-sc.sh | SC-8 |
| `SC-28-config-perm` | check-sc.sh | SC-28 |
| `SC-28-config-owner` | check-sc.sh | SC-28 |
| `SC-28-world-readable-secrets` | check-sc.sh | SC-28 |

## Test plan

- [x] `bash tests/integration/host-only-mode.sh` — 7/7 passing
- [x] JSON catalog validates cleanly
- [x] All check scripts pass `bash -n` syntax check
- [ ] Manual: run `./assessment/assess.sh` (default) — agent checks appear
- [ ] Manual: run `./assessment/assess.sh --host-only` — agent checks absent
- [ ] Pester: `Invoke-Pester -Path tests/Pester/windows-host-only.Tests.ps1` on Windows

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)