### PR TITLE
chore: enable Dependabot for GitHub Actions and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to keep CI actions and Docker base images current
- GitHub Actions ecosystem: weekly check on Mondays
- Docker ecosystem: weekly check on Mondays

## Test plan
- [ ] Verify Dependabot picks up the config and shows the two ecosystems in the repo's Dependabot settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)