### PR TITLE
Fix README version badge (v0.1.1 -> v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Focus Forward. We've Got Your Six.** — Oscar Six Security LLC
 
-[![Version](https://img.shields.io/badge/version-v0.1.1-green)](https://github.com/oscarsixsecllc/sarge/releases)
+[![Version](https://img.shields.io/badge/version-v0.7.0-green)](https://github.com/oscarsixsecllc/sarge/releases)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Ubuntu%20%7C%20macOS%20%7C%20Windows-orange)](docs/quickstart.md)
 


### PR DESCRIPTION
## Summary
- Updates the shields.io version badge from v0.1.1 to v0.7.0 to match the latest release

Closes #69

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>