### PR TITLE
feat: expand NIST 800-53 coverage to 63 controls across 12 families

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sarge is an open source NIST 800-53 Rev 5 hardening standard, gap analysis tool,
 
 ## What Sarge Does
 
-- 📋 **Gap Analysis** — Scans your OpenClaw instance and underlying OS against a documented 800-53 baseline. Produces a structured report: control ID, status (pass/warn/fail), current value, required value, and remediation steps. **68 checks across 7 control groups** (6 NIST families + AS agent-safety overlay) on a standard Ubuntu 24.04 host with OpenClaw 2026.7.x.
+- 📋 **Gap Analysis** — Scans your OpenClaw instance and underlying OS against a documented 800-53 baseline. Produces a structured report: control ID, status (pass/warn/fail), current value, required value, and remediation steps. **63 controls across 12 NIST families + AS agent-safety overlay** on a standard Ubuntu 24.04 host with OpenClaw 2026.7.x. See [NIST 800-53 Rev 5 Control Coverage](#nist-800-53-rev-5-control-coverage) below for the full per-control breakdown.
 - 🔒 **Hardening Scripts** — Idempotent, auditable bash scripts for UFW, auditd, PAM (faillock + pwquality), fail2ban, systemd service hardening, and file permissions.
 - 📸 **Drift Detection** — Compares current system state against a captured baseline. Any drift generates a notification via your OpenClaw-configured channel.
 - 🗺️ **Control Mapping** — Every OpenClaw setting and OS-level recommendation mapped to its 800-53 control ID, in both JSON and Markdown.
@@ -77,6 +77,144 @@ pwsh assessment/assess.ps1 --host-only
 ```
 
 In host-only mode, agent-scoped findings are excluded entirely (not even SKIP — they're out of scope). The report header states which mode the run used. See [#50](https://github.com/oscarsixsecllc/sarge/issues/50) for details.
+
+---
+
+## NIST 800-53 Rev 5 Control Coverage
+
+Sarge's baseline (`baseline/controls.json`) documents 63 individual NIST 800-53 Rev 5 controls across 12 families. Each control lists the exact OpenClaw settings and OS-level checks Sarge inspects, plus remediation guidance.
+
+### Summary by family
+
+- **AC — Access Control** — 12 controls — Partial (11 full, 1 partial)
+- **AU — Audit and Accountability** — 10 controls — Full
+- **CM — Configuration Management** — 7 controls — Partial (6 full, 1 partial)
+- **IA — Identification and Authentication** — 7 controls — Full
+- **SC — System and Communications Protection** — 11 controls — Full
+- **SI — System and Information Integrity** — 7 controls — Partial (4 full, 3 partial)
+- **CP — Contingency Planning** — 2 controls — Partial (1 full, 1 partial)
+- **CA — Assessment, Authorization, and Monitoring** — 2 controls — Partial (1 full, 1 partial)
+- **SA — System and Services Acquisition** — 2 controls — Partial (both partial)
+- **MP — Media Protection** — 1 control — Partial
+- **SR — Supply Chain Risk Management** — 1 control — Partial
+- **RA — Risk Assessment** — 1 control — Full
+
+"Full" means the control has a fully automatable check with a concrete pass/fail verdict. "Partial" means Sarge checks what it can automate, but part of the control (a policy decision, an external agreement, or something outside what a scanner can verify) still needs human review.
+
+---
+
+### AC — Access Control (12 controls)
+
+- **AC-2 — Account Management** (full) — Checks `agents.allowlist`, `channels.*.allowedUsers`, `gateway.nodes.pairing.autoApproveCidrs`; OS: `getent passwd`, `lastlog`, `who`. Remediation: remove unused accounts, restrict the OpenClaw allowlist to named users only.
+- **AC-3 — Access Enforcement** (full) — Checks `tools.fs.workspaceOnly`, `agents.defaults.sandbox.mode`, `browser.attachOnly`, `browser.noSandbox`, `browser.evaluateEnabled`, `hooks.allowRequestSessionKey`, `hooks.allowedAgentIds`, `commands.ownerAllowFrom`, `gateway.controlUi.allowedOrigins`, `gateway.controlUi.allowInsecureAuth`, `approvals.exec.enabled`, `acp.allowedAgents`, `tools.codeMode.enabled`, `tools.sandbox.tools.alsoAllow`, `gateway.nodes.allowCommands`, `gateway.nodes.denyCommands`, `nodeHost.browserProxy.enabled`, `nodeHost.browserProxy.allowProfiles`, `crestodian.rescue.ownerDmOnly`, `talk.realtime.consultRouting`; OS: file permissions on `~/.openclaw/`, sudoers review. Remediation: set `workspaceOnly=true`, set sandbox mode to `all`, restrict sudoers, disable browser `noSandbox`, set `hooks.allowRequestSessionKey=false`.
+- **AC-4 — Information Flow Enforcement** (full) — Checks `session.dmScope`, `messages.groupChat.visibleReplies`, `tools.web.search.enabled`, `tools.web.fetch.enabled`, `diagnostics.otel.captureContent.enabled`, `broadcast.strategy`, `acp.stream.maxOutputChars`, `surfaces.*.silentReply`. Remediation: set `session.dmScope` to `per-channel-peer`, review `tools.web` settings, disable `diagnostics.otel.captureContent` unless the collector is within your data boundary.
+- **AC-5 — Separation of Duties** (full) — OS: `whoami`, `groups <user>`. Remediation: run OpenClaw under a dedicated service account that is not a member of the sudo/admin group.
+- **AC-6 — Least Privilege** (full) — Checks `tools.exec.elevated`, `agents.defaults.sandbox.mode`, `agents.defaults.subagents.allowChildOverrides`, `gateway.terminal.enabled`, `browser.evaluateEnabled`; OS: `sudo -l`, `groups <user>`. Remediation: disable elevated exec unless required, confirm the service account has no unnecessary group memberships, set `subagents.allowChildOverrides=false`, disable the gateway terminal.
+- **AC-7 — Unsuccessful Logon Attempts** (full) — Checks `gateway.auth.rateLimit.maxAttempts`, `gateway.auth.rateLimit.windowMs`, `gateway.auth.rateLimit.lockoutMs`, `auth.cooldowns`; OS: `pam_faillock status`. Remediation: configure `gateway.auth.rateLimit` (maxAttempts=10, windowMs=60000, lockoutMs=300000), configure PAM faillock.
+- **AC-8 — System Use Notification** (full) — OS: `grep ^Banner /etc/ssh/sshd_config`. Remediation: set a `Banner` directive in `sshd_config` pointing to a system-use notification file.
+- **AC-10 — Concurrent Session Control** (partial) — OS: `grep maxlogins /etc/security/limits.conf`. Remediation: set a `maxlogins` limit in `/etc/security/limits.conf` to bound concurrent sessions per user.
+- **AC-11 — Device Lock** (full) — OS: `grep TMOUT /etc/profile /etc/profile.d/*`. Remediation: set `TMOUT` in `/etc/profile` or `/etc/profile.d/` to auto-lock idle shell sessions.
+- **AC-12 — Session Termination** (full) — Checks `mcp.sessionIdleTtlMs`, `agents.defaults.subagents.archiveAfterMinutes`, `cron.sessionRetention`, `acp.runtime.ttlMinutes`, `crestodian.rescue.pendingTtlMinutes`. Remediation: set `mcp.sessionIdleTtlMs` to 600000 (10 min), set `subagents.archiveAfterMinutes` to 60, review `cron.sessionRetention`.
+- **AC-14 — Permitted Actions Without Identification or Authentication** (full) — Checks `auth.enabled`. Remediation: set `auth.enabled` to `true` so gateway actions require identification/authentication.
+- **AC-17 — Remote Access** (full) — Checks `gateway.bind`, `gateway.auth.mode`, `gateway.auth.rateLimit`, `gateway.controlUi.allowedOrigins`, `gateway.terminal.enabled`, `hooks.enabled`; OS: `ufw status`, `ss -tlnp`. Remediation: bind the gateway to loopback, enable `gateway.auth.mode=token`, set an auth rate limit, disable external hooks and the gateway terminal.
+
+### AU — Audit and Accountability (10 controls)
+
+- **AU-2 — Event Logging** (full) — Checks `logging.level`, `logging.destination`; OS: `systemctl status auditd`, `auditctl -l`. Remediation: enable auditd, set OpenClaw logging level to `info` or higher.
+- **AU-3 — Content of Audit Records** (full) — Checks `logging.includeTimestamp`, `logging.includeUser`; OS: `ausearch -m LOGIN`, `last`. Remediation: ensure audit records include timestamp, user, action, and outcome.
+- **AU-4 — Audit Log Storage Capacity** (full) — OS: `df -P /var/log/audit`, `df -P /var/log`. Remediation: keep at least 10% free space on the audit log partition; configure log rotation with adequate headroom or expand storage.
+- **AU-5 — Response to Audit Processing Failures** (full) — OS: `grep disk_full_action /etc/audit/auditd.conf`, `grep admin_space_left_action /etc/audit/auditd.conf`. Remediation: set `disk_full_action` and `admin_space_left_action` to something other than `IGNORE` (e.g. `SYSLOG`, `EMAIL`, `HALT`).
+- **AU-6 — Audit Review, Analysis, and Reporting** (full) — Checks `security.audit.suppressions`; OS: `auditctl -l`. Remediation: review every `security.audit.suppressions` entry — each suppression must be justified and periodically reviewed, or it creates a blind spot.
+- **AU-7 — Audit Record Reduction and Report Generation** (full) — OS: `which journalctl`, `which ausearch`, `grep -r '@' /etc/rsyslog.d/`. Remediation: install auditd (provides `ausearch`) or configure rsyslog forwarding so audit records can be queried and aggregated.
+- **AU-8 — Time Stamps** (full) — OS: `timedatectl show -p NTPSynchronized`, `chronyc tracking`. Remediation: enable NTP sync — `sudo timedatectl set-ntp true`.
+- **AU-9 — Protection of Audit Information** (full) — Checks `agents.defaults.compaction.mode`, `agents.defaults.compaction.memoryFlush.enabled`, `logging.redactSensitive`; OS: `ls -la /var/log/audit/`, `stat /var/log/audit/audit.log`. Remediation: audit logs must be owned by root, mode 600; restrict write access.
+- **AU-11 — Audit Record Retention** (full) — OS: `grep rotate /etc/logrotate.d/auditd`. Remediation: configure logrotate for audit logs with a `rotate` count of at least 4 (weekly rotation) for minimum retention.
+- **AU-12 — Audit Record Generation** (full) — Checks `logging.auditActions`, `transcripts.enabled`, `transcripts.autoStart`; OS: `auditctl -l | grep openclaw`. Remediation: add auditd watch rules for `~/.openclaw/secrets/` and OpenClaw config files; review `transcripts.autoStart` sources.
+
+### CM — Configuration Management (7 controls)
+
+- **CM-2 — Baseline Configuration** (full) — Checks `*` (all settings against baseline); OS: `dpkg --get-selections`, `systemctl list-units --state=enabled`. Remediation: maintain `openclaw.json.baseline` as the documented configuration baseline.
+- **CM-3 — Configuration Change Control** (full) — Checks `gateway.reload.mode`, `update.auto.enabled`, `commands.restart`. Remediation: set `gateway.reload.mode` to `hybrid`, disable `update.auto` unless `stableDelayHours >= 6`, review restart command availability.
+- **CM-5 — Access Restrictions for Change** (full) — Checks `skills.workshop.approvalPolicy`, `skills.install.allowUploadedArchives`, `skills.workshop.allowSymlinkTargetWrites`, `plugins.entries`. Remediation: set `skills.workshop.approvalPolicy` to `review`, disable `allowUploadedArchives` and `allowSymlinkTargetWrites`, review plugin entries for `hooks.allowPromptInjection`.
+- **CM-6 — Configuration Settings** (full) — Checks `tools.fs.workspaceOnly`, `agents.defaults.sandbox.mode`, `gateway.bind`, `models.mode`, `session.dmScope`, `messages.groupChat.visibleReplies`, `cron.maxConcurrentRuns`; OS: `ufw status verbose`, `sshd -T | grep -i permit`. Remediation: apply all settings in `openclaw.json.baseline` and all Sarge hardening scripts; verify `models.mode`, `session.dmScope`, and cron settings match baseline.
+- **CM-7 — Least Functionality** (full) — Checks `plugins.entries`, `plugins.slots`, `tools.web`, `tools.codeMode.enabled`, `skills.entries`, `skills.workshop.approvalPolicy`, `skills.install.allowUploadedArchives`, `skills.load.allowSymlinkTargets`, `browser.enabled`, `browser.evaluateEnabled`, `browser.ssrfPolicy`, `mcp.servers`, `discovery.mdns.mode`, `gateway.http.endpoints.chatCompletions.enabled`, `gateway.http.endpoints.responses.enabled`, `gateway.tools.deny`, `gateway.tools.allow`, `commitments.enabled`, `security.installPolicy.enabled`, `marketplaces.feeds`, `marketplaces.sources`, `audio.transcription.command`; OS: `systemctl list-units --state=enabled`, `apt list --installed`. Remediation: disable unused plugins/skills/tools, set `skills.workshop.approvalPolicy=review`, disable the browser unless needed, set `discovery.mdns.mode=minimal`, remove unnecessary OS packages.
+- **CM-8 — System Component Inventory** (full) — Checks `mcp.servers`, `plugins.entries`; OS: `node --version`. Remediation: maintain an approved component list and reconcile it against the reported Node.js version, MCP servers, and plugins.
+- **CM-11 — User-Installed Software** (partial) — OS: `npm list -g --depth=0`. Remediation: review globally-installed npm packages and remove any not approved for the host.
+
+### IA — Identification and Authentication (7 controls)
+
+- **IA-2 — Identification and Authentication (Org Users)** (full) — Checks `channels.*.allowedUsers`; OS: `pam_faillock status`, `grep pam_faillock /etc/pam.d/common-auth`. Remediation: enable PAM faillock; restrict OpenClaw to authenticated Discord/channel users only.
+- **IA-4 — Identifier Management** (full) — OS: `awk -F: '{print $3}' /etc/passwd | sort | uniq -d`. Remediation: eliminate duplicate UIDs in `/etc/passwd`; never reuse a UID after deleting an account.
+- **IA-5 — Authenticator Management** (full) — Checks `auth.profiles`, `auth.order`, `auth.cooldowns`, `secrets.providers`, `gateway.auth.token`; OS: `grep minlen /etc/security/pwquality.conf`, `grep PASS_MAX_DAYS /etc/login.defs`. Remediation: set pwquality `minlen=12` plus complexity rules; set `PASS_MAX_DAYS=90`, `PASS_MIN_DAYS=1`.
+- **IA-6 — Authentication Feedback** (full) — OS: `grep pam_unix /etc/pam.d/common-auth`. Remediation: ensure login failure messages don't reveal whether the username or password was wrong.
+- **IA-7 — Cryptographic Module Authentication** (full) — Checks `gateway.tls`; OS: `grep Protocol /etc/ssh/sshd_config`, `grep Ciphers /etc/ssh/sshd_config`. Remediation: disable SSHv1 and weak ciphers (3DES, RC4/arcfour, CBC-mode) in `sshd_config`; set gateway TLS `minVersion` to TLSv1.2 or higher.
+- **IA-8 — Identification and Authentication (Non-Org Users)** (full) — Checks `auth.mode`, `auth.providers`. Remediation: set an explicit `auth.mode`, register `auth.providers`, and disable anonymous access so external channel users (Discord/Telegram/etc.) are identified before gateway trust.
+- **IA-11 — Re-authentication** (full) — Checks `mcp.sessionIdleTtlMs`. Remediation: set `mcp.sessionIdleTtlMs` to a finite, reasonable value (e.g. 24h or less) so idle sessions require re-authentication.
+
+### SC — System and Communications Protection (11 controls)
+
+- **SC-2 — Application Partitioning** (full) — OS: `ps aux`, `readlink /proc/PID/ns/mnt`. Remediation: run OpenClaw under a dedicated non-root service account; consider container or namespace isolation.
+- **SC-4 — Information in Shared Resources** (full) — OS: `find /tmp -name *openclaw*`, `ls /dev/shm`. Remediation: configure periodic cleanup of `/tmp` session data; review `/dev/shm` for sensitive residue.
+- **SC-5 — Denial-of-Service Protection** (full) — Checks `models.rateLimit`, `agents.defaults.maxConcurrent`, `agents.defaults.subagents.maxConcurrent`, `cron.maxConcurrentRuns`, `gateway.auth.rateLimit`, `acp.maxConcurrentSessions`, `acp.stream.maxOutputChars`, `audio.transcription.timeoutSeconds`; OS: `ufw status`. Remediation: set per-model rate limits, bound `maxConcurrent` to 4 for agents / 8 for subagents, set `cron.maxConcurrentRuns` to 8.
+- **SC-7 — Boundary Protection** (full) — Checks `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork`, `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback`, `discovery.mdns.mode`, `hooks.enabled`, `gateway.tailscale.mode`, `proxy.enabled`, `proxy.loopbackMode`, `nodeHost.browserProxy.enabled`, `web.enabled`; OS: `ufw status`, `ss -tlnp`. Remediation: set `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork=false`, set `discovery.mdns.mode=minimal`, disable external hooks unless required.
+- **SC-8 — Transmission Confidentiality and Integrity** (full) — Checks `gateway.tls.enabled`, `gateway.controlUi.allowInsecureAuth`, `mcp.servers`; OS: `ss -tlnp`, `openssl s_client -connect localhost:18790`. Remediation: enable TLS on the gateway; use Cloudflare Tunnel (TLS enforced) for all remote access.
+- **SC-12 — Cryptographic Key Establishment and Management** (full) — OS: `stat ~/.openclaw/secrets/*.key`, `stat ~/.ssh/id_*`. Remediation: all key/credential files must be 600 or 400; SSH private keys must be 600.
+- **SC-13 — Cryptographic Protection** (full) — OS: `openssl version`, `node --version`. Remediation: use OpenSSL 1.1+ or 3.x for FIPS capability; Node.js 18+ enforces TLS 1.2+ by default.
+- **SC-15 — Collaborative Computing Devices** (full) — Checks `nodes.*.capabilities.camera`, `nodes.*.capabilities.microphone`; OS: `v4l2-ctl --list-devices`, `ls /dev/video*`. Remediation: disable camera/microphone capabilities in `openclaw.json` unless required; remove `/dev/video*` access for the agent user.
+- **SC-23 — Session Authenticity** (full) — Checks `auth.enabled`, `gatewayToken`. Remediation: set `auth.enabled: true` and configure a strong `gatewayToken`.
+- **SC-28 — Protection of Information at Rest** (full) — Checks `memory.encryption`, `secrets.providers`, `logging.redactSensitive`, `diagnostics.otel.captureContent.enabled`, `diagnostics.cacheTrace.enabled`, `env`, `media.preserveFilenames`, `media.ttlHours`; OS: `stat ~/.openclaw/secrets/`, `ls -la ~/.openclaw/`. Remediation: secrets directory must be 700; all secret files must be 600; owner must be the service account only.
+- **SC-39 — Process Isolation** (full) — OS: `cat /proc/PID/cgroup`, `readlink /proc/PID/ns/{pid,net,mnt}`. Remediation: run OpenClaw in a container or systemd slice with resource limits; use network and PID namespaces to isolate the agent.
+
+### SI — System and Information Integrity (7 controls)
+
+- **SI-2 — Flaw Remediation** (partial) — OS: `apt list --upgradable`, `unattended-upgrades --dry-run`. Remediation: enable unattended-upgrades for security patches; review and apply pending updates.
+- **SI-3 — Malicious Code Protection** (partial) — OS: `which clamav`, `systemctl status clamav-daemon`. Remediation: install and configure ClamAV or equivalent; schedule regular scans.
+- **SI-4 — Information System Monitoring** (full) — Checks `diagnostics.enabled`, `audit.enabled`, `cron.failureAlert.enabled`, `security.audit.suppressions`; OS: `systemctl status auditd`. Remediation: enable diagnostics, audit, and `cron.failureAlert`; enable auditd on the host; review `security.audit.suppressions` for blind spots.
+- **SI-7 — Software, Firmware, and Information Integrity** (partial) — OS: `apt-config dump | grep -i AllowUnauthenticated`, `ls /etc/apt/trusted.gpg.d/`. Remediation: ensure `APT::Get::AllowUnauthenticated` is unset or false; verify apt repository GPG keys are configured under `/etc/apt/trusted.gpg.d/`.
+- **SI-12 — Information Management and Retention** (full) — Checks `agents.defaults.compaction.mode`, `agents.defaults.compaction.memoryFlush.enabled`, `agents.defaults.compaction.truncateAfterCompaction`, `transcripts.enabled`, `transcripts.maxUtterances`, `media.ttlHours`. Remediation: set `compaction.mode` to `safeguard`, enable `memoryFlush` and `truncateAfterCompaction`, review `transcripts.maxUtterances` and `media.ttlHours` retention bounds.
+- **SI-16 — Memory Protection** (full) — OS: `cat /proc/sys/kernel/randomize_va_space`. Remediation: set `kernel.randomize_va_space=2` for full ASLR — `sudo sysctl -w kernel.randomize_va_space=2`.
+- **SI-17 — Fail-Safe Procedures** (full) — Checks `cron.retry.maxAttempts`, `crestodian.rescue.enabled`, `crestodian.rescue.pendingTtlMinutes`. Remediation: bound `cron.retry.maxAttempts`; if crestodian rescue is enabled, set a short `pendingTtlMinutes`.
+
+### CP — Contingency Planning (2 controls)
+
+- **CP-9 — System Backup** (partial) — OS: `crontab -l | grep -i backup`, `systemctl list-timers --all | grep -i backup`. Remediation: configure a scheduled backup (cron or systemd timer) of `~/.openclaw` config, secrets, and workspace state; verify backups are recoverable.
+- **CP-10 — System Recovery and Reconstitution** (full) — Checks `crestodian.rescue.enabled`, `crestodian.rescue.ownerDmOnly`, `crestodian.rescue.pendingTtlMinutes`. Remediation: if rescue mode is enabled, restrict to `ownerDmOnly=true`; set `pendingTtlMinutes` to a short window (5 min default) to prevent stale rescue state.
+
+### CA — Assessment, Authorization, and Monitoring (2 controls)
+
+- **CA-7 — Continuous Monitoring** (full) — Checks `security.installPolicy.enabled`, `security.audit.suppressions`, `diagnostics.enabled`; OS: `systemctl status auditd`, `unattended-upgrades --dry-run`. Remediation: enable `security.installPolicy`, review audit suppressions, enable diagnostics.
+- **CA-9 — Internal System Connections** (partial) — Checks `mcp.servers`; OS: parse `~/.openclaw/openclaw.json` `mcp.servers`. Remediation: document each MCP server connection in the system security plan / interconnection agreements; remove any unused or unauthorized servers.
+
+### SA — System and Services Acquisition (2 controls)
+
+- **SA-9 — External System Services** (partial) — Checks `mcp.servers`. Remediation: review each configured `mcp.servers` entry for a data-sharing agreement and supply-chain risk assessment; remove servers that are no longer needed.
+- **SA-22 — Unsupported System Components** (partial) — OS: `cat /etc/os-release`, `node --version`. Remediation: upgrade Ubuntu and Node.js before their end-of-life dates; track EOL schedules at endoflife.date.
+
+### MP — Media Protection (1 control)
+
+- **MP-6 — Media Sanitization** (partial) — Checks `media.ttlHours`, `media.maxSizeMb`. Remediation: set `media.ttlHours` to a positive retention window and `media.maxSizeMb` to bound stored media size in the OpenClaw config.
+
+### SR — Supply Chain Risk Management (1 control)
+
+- **SR-11 — Component Authenticity** (partial) — OS: `ls ~/.openclaw/skills`, `ls /etc/apt/trusted.gpg.d/`. Remediation: add source/author/origin metadata to installed skills; verify APT package signing keys are present under `/etc/apt/trusted.gpg.d/`.
+
+### RA — Risk Assessment (1 control)
+
+- **RA-5 — Vulnerability Monitoring and Scanning** (full) — OS: `trivy`/`grype`/`oscap`/`lynis`/`debsecan`, `npm audit`, `apt list --upgradable`. Remediation: install a vulnerability scanner (trivy or grype recommended), run `npm audit` on OpenClaw dependencies, apply pending OS security patches.
+
+### Families not covered
+
+Sarge does not attempt to automate 7 of the 19 NIST 800-53 Rev 5 families, because they're organizational, administrative, or physical-security controls that a host/config scanner cannot meaningfully verify:
+
+- **AT — Awareness and Training** — training program content and completion tracking, not a system state.
+- **IR — Incident Response** — response plans, playbooks, and tabletop exercises are process artifacts, not scannable config.
+- **MA — Maintenance** — maintenance scheduling, tooling, and personnel controls.
+- **PE — Physical and Environmental Protection** — facility access, environmental controls — not visible to a host-level scan.
+- **PL — Planning** — system security plans and policy documents.
+- **PM — Program Management** — organization-wide security program governance.
+- **PS — Personnel Security** — background checks, termination procedures, personnel screening.
+
+These require documentation review and organizational process audit, not automated scanning — they're out of scope for a tool that inspects OpenClaw config and OS state.
 
 ---
 

--- a/assessment/checks/check-ac.sh
+++ b/assessment/checks/check-ac.sh
@@ -90,3 +90,152 @@ if [[ -z "$LISTENING" ]]; then
 else
   warnx "AC-17-external-ports" "AC-17: Externally-listening ports found — review: $(echo "$LISTENING" | tr '\n' ' ')"
 fi
+
+# AC-4: Information Flow Enforcement — OpenClaw outbound network restriction
+#
+# Live OpenClaw 2026.7.x writes runtime config to `openclaw.json`; older
+# installs used `config.json`. Same fallback probe as check-ia.sh / check-sa.sh
+# (issue #61).
+log "AC-4: Information Flow Enforcement"
+AC_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    AC_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$AC_OC_CONFIG" ]]; then
+  AC_CONFIG_NAME=$(basename "$AC_OC_CONFIG")
+  if grep -qE '"allowedHosts"' "$AC_OC_CONFIG" 2>/dev/null; then
+    passx "AC-4-network-isolation" "AC-4: network.allowedHosts is configured in $AC_CONFIG_NAME"
+  else
+    warnx "AC-4-network-isolation" "AC-4: No network.allowedHosts restriction found in $AC_CONFIG_NAME — outbound network access is unrestricted"
+  fi
+else
+  skipx "AC-4-network-isolation" "AC-4: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# AC-5: Separation of Duties — agent account vs. system admin account
+log "AC-5: Separation of Duties"
+AC5_USER=$(whoami)
+AC5_ADMIN_GROUP=$(platform admin_group_name)
+if [[ -d "$HOME/.openclaw" ]] && platform user_in_admin_group "$AC5_USER"; then
+  warnx "AC-5-agent-admin-same-account" "AC-5: $AC5_USER runs OpenClaw and is a member of the $AC5_ADMIN_GROUP group — agent and system-admin accounts should be separated"
+else
+  passx "AC-5-agent-admin-same-account" "AC-5: OpenClaw account ($AC5_USER) is not in the $AC5_ADMIN_GROUP admin group, or no OpenClaw install detected"
+fi
+
+# AC-7: Unsuccessful Logon Attempts — pam_faillock lockout policy
+log "AC-7: Unsuccessful Logon Attempts"
+if ! platform_supports pam_faillock_configured; then
+  skipx "AC-7-faillock-not-configured" "AC-7: pam_faillock is a Linux-PAM construct; on ${SARGE_OS_DESCRIPTION} account lockout is enforced via pwpolicy / MDM account policies"
+elif platform pam_faillock_configured; then
+  AC7_DENY=$(platform faillock_value deny)
+  if [[ -n "$AC7_DENY" && "$AC7_DENY" -ge 3 ]]; then
+    passx "AC-7-faillock-deny" "AC-7: pam_faillock deny is $AC7_DENY (lockout after $AC7_DENY attempts)"
+  else
+    warnx "AC-7-faillock-deny" "AC-7: pam_faillock deny is ${AC7_DENY:-unset} — recommend 3 or more failed attempts before lockout"
+  fi
+else
+  failx "AC-7-faillock-not-configured" "AC-7: pam_faillock not referenced in common-auth — no unsuccessful-logon lockout configured"
+fi
+
+# AC-8: System Use Notification — SSH login banner
+#
+# Reuses the sshd_config + sshd_config.d drop-in discovery pattern from
+# CM-7's SSH section (check-cm.sh) — see that file's comment for the
+# first-match-wins rationale.
+log "AC-8: System Use Notification"
+if platform sshd_active; then
+  AC8_SSHD_CONFIG=$(platform sshd_config_path)
+  _AC8_SSHD_CONF_FILES=("$AC8_SSHD_CONFIG")
+  AC8_SSHD_DROPIN_DIR="${AC8_SSHD_CONFIG%/*}/sshd_config.d"
+  if [[ -d "$AC8_SSHD_DROPIN_DIR" ]]; then
+    while IFS= read -r f; do
+      _AC8_SSHD_CONF_FILES+=("$f")
+    done < <(find "$AC8_SSHD_DROPIN_DIR" -maxdepth 1 -name '*.conf' -type f 2>/dev/null | sort)
+  fi
+  if grep -qiE "^Banner\s+\S" "${_AC8_SSHD_CONF_FILES[@]}" 2>/dev/null; then
+    passx "AC-8-ssh-banner" "AC-8: SSH login Banner is configured"
+  else
+    warnx "AC-8-ssh-banner" "AC-8: No SSH Banner directive found — configure a system-use notification banner"
+  fi
+else
+  skipx "AC-8-ssh-banner" "AC-8: SSH server not active — banner check not applicable"
+fi
+
+# AC-10: Concurrent Session Control — limits.conf maxlogins
+log "AC-10: Concurrent Session Control"
+AC10_LIMITS_CONF="/etc/security/limits.conf"
+if [[ -f "$AC10_LIMITS_CONF" ]] && grep -qE "maxlogins" "$AC10_LIMITS_CONF" 2>/dev/null; then
+  passx "AC-10-maxlogins" "AC-10: maxlogins limit configured in $AC10_LIMITS_CONF"
+else
+  warnx "AC-10-maxlogins" "AC-10: No maxlogins limit configured in $AC10_LIMITS_CONF — concurrent sessions are unbounded"
+fi
+
+# AC-11: Device Lock — shell session idle timeout (TMOUT)
+log "AC-11: Device Lock"
+AC11_TMOUT=$(platform session_timeout_setting)
+if [[ -n "$AC11_TMOUT" ]]; then
+  passx "AC-11-session-timeout" "AC-11: Session timeout is configured: $AC11_TMOUT"
+else
+  warnx "AC-11-session-timeout" "AC-11: No TMOUT session timeout configured — idle sessions do not auto-lock"
+fi
+
+# AC-12: Session Termination — OpenClaw session idle timeout
+log "AC-12: Session Termination"
+AC_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    AC_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$AC_OC_CONFIG" ]]; then
+  AC_CONFIG_NAME=$(basename "$AC_OC_CONFIG")
+  AC12_IDLE_MIN=$(grep -oE '"idleTimeoutMinutes"[[:space:]]*:[[:space:]]*[0-9]+' "$AC_OC_CONFIG" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+  if [[ -n "$AC12_IDLE_MIN" ]]; then
+    passx "AC-12-session-idle-timeout" "AC-12: sessions.idleTimeoutMinutes is $AC12_IDLE_MIN in $AC_CONFIG_NAME"
+  else
+    warnx "AC-12-session-idle-timeout" "AC-12: sessions.idleTimeoutMinutes not set in $AC_CONFIG_NAME — sessions may never auto-terminate"
+  fi
+else
+  skipx "AC-12-session-idle-timeout" "AC-12: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# AC-14: Permitted Actions Without Identification or Authentication
+log "AC-14: Permitted Actions Without Identification"
+AC_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    AC_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$AC_OC_CONFIG" ]]; then
+  AC_CONFIG_NAME=$(basename "$AC_OC_CONFIG")
+  AC14_AUTH_ENABLED=""
+  if command -v jq &>/dev/null; then
+    AC14_AUTH_ENABLED=$(jq -r '.auth.enabled // empty' "$AC_OC_CONFIG" 2>/dev/null)
+  elif command -v python3 &>/dev/null; then
+    AC14_AUTH_ENABLED=$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    v = (d.get("auth") or {}).get("enabled")
+    if v is not None:
+        print(str(v).lower())
+except Exception:
+    pass
+' "$AC_OC_CONFIG" 2>/dev/null)
+  fi
+  if [[ "$AC14_AUTH_ENABLED" == "false" ]]; then
+    failx "AC-14-auth-disabled" "AC-14: OpenClaw auth.enabled is false in $AC_CONFIG_NAME — the gateway permits actions without identification"
+  elif [[ "$AC14_AUTH_ENABLED" == "true" ]]; then
+    passx "AC-14-auth-disabled" "AC-14: OpenClaw auth.enabled is true in $AC_CONFIG_NAME"
+  else
+    warnx "AC-14-auth-disabled" "AC-14: No explicit auth.enabled found in $AC_CONFIG_NAME — verify unauthenticated access is not permitted"
+  fi
+else
+  skipx "AC-14-auth-disabled" "AC-14: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi

--- a/assessment/checks/check-au.sh
+++ b/assessment/checks/check-au.sh
@@ -86,3 +86,87 @@ else
     warnx "AU-2-journal-not-persisted" "AU-2: Journal persistence unclear — verify /etc/systemd/journald.conf Storage setting"
   fi
 fi
+
+# AU-4: Audit log storage capacity
+log "AU-4: Audit log storage capacity"
+if ! platform_supports log_partition_free_pct; then
+  skipx "AU-4-log-storage" "AU-4: audit log partition free-space check is Linux-specific; not applicable on ${SARGE_OS_DESCRIPTION}"
+else
+  FREE_PCT=$(platform log_partition_free_pct)
+  if [[ -z "$FREE_PCT" ]]; then
+    warnx "AU-4-log-storage" "AU-4: could not determine free space on the audit log partition"
+  elif [[ "$FREE_PCT" -gt 10 ]]; then
+    passx "AU-4-log-storage" "AU-4: audit log partition has ${FREE_PCT}% free — adequate headroom"
+  else
+    failx "AU-4-log-storage" "AU-4: audit log partition has only ${FREE_PCT}% free — expand storage or tighten log rotation"
+  fi
+fi
+
+# AU-5: Response to audit failures
+log "AU-5: Response to audit failures"
+if ! platform_supports auditd_config_value; then
+  skipx "AU-5-audit-failure-response" "AU-5: auditd.conf inspection is a Linux auditd construct; not applicable on ${SARGE_OS_DESCRIPTION}"
+elif [[ ! -f "$(platform auditd_config_path)" ]]; then
+  skipx "AU-5-audit-failure-response" "AU-5: $(platform auditd_config_path) not found — auditd may not be installed"
+else
+  DISK_FULL_ACTION=$(platform auditd_config_value "disk_full_action")
+  SPACE_LEFT_ACTION=$(platform auditd_config_value "admin_space_left_action")
+  if [[ -n "$DISK_FULL_ACTION" && "${DISK_FULL_ACTION^^}" != "IGNORE" \
+        && -n "$SPACE_LEFT_ACTION" && "${SPACE_LEFT_ACTION^^}" != "IGNORE" ]]; then
+    passx "AU-5-audit-failure-response" "AU-5: disk_full_action=$DISK_FULL_ACTION, admin_space_left_action=$SPACE_LEFT_ACTION"
+  else
+    warnx "AU-5-audit-failure-response" "AU-5: disk_full_action=${DISK_FULL_ACTION:-unset}, admin_space_left_action=${SPACE_LEFT_ACTION:-unset} — set both to something other than IGNORE (e.g. SYSLOG, EMAIL, HALT)"
+  fi
+fi
+
+# AU-7: Audit reduction and report generation
+log "AU-7: Audit reduction and report generation"
+if ! platform_supports journalctl_available; then
+  skipx "AU-7-log-tooling" "AU-7: journalctl/ausearch availability check is Linux-specific; not applicable on ${SARGE_OS_DESCRIPTION}"
+else
+  TOOLING_NOTE=""
+  if platform journalctl_available; then
+    TOOLING_NOTE="journalctl"
+  fi
+  if platform_supports ausearch_available && platform ausearch_available; then
+    TOOLING_NOTE="${TOOLING_NOTE:+$TOOLING_NOTE, }ausearch"
+  fi
+  if platform_supports syslog_forwarding_configured && platform syslog_forwarding_configured; then
+    TOOLING_NOTE="${TOOLING_NOTE:+$TOOLING_NOTE, }syslog forwarding"
+  fi
+  if [[ -n "$TOOLING_NOTE" ]]; then
+    passx "AU-7-log-tooling" "AU-7: log query/aggregation tooling available ($TOOLING_NOTE)"
+  else
+    warnx "AU-7-log-tooling" "AU-7: no log query/aggregation tooling detected — install auditd (ausearch) or configure syslog forwarding"
+  fi
+fi
+
+# AU-8: Time stamps
+log "AU-8: Time stamps"
+if ! platform_supports time_sync_active; then
+  skipx "AU-8-time-sync" "AU-8: NTP sync check via timedatectl/chronyc is Linux-specific; verify time sync via ${SARGE_OS_DESCRIPTION} equivalent separately"
+elif platform time_sync_active; then
+  passx "AU-8-time-sync" "AU-8: system clock is synchronized (NTP)"
+else
+  failx "AU-8-time-sync" "AU-8: system clock is not synchronized — enable NTP: sudo timedatectl set-ntp true"
+fi
+
+# AU-11: Audit record retention
+log "AU-11: Audit record retention"
+if ! platform_supports logrotate_audit_config_path; then
+  skipx "AU-11-log-retention" "AU-11: logrotate inspection is a Linux construct; not applicable on ${SARGE_OS_DESCRIPTION}"
+else
+  LOGROTATE_CONF=$(platform logrotate_audit_config_path)
+  if [[ ! -f "$LOGROTATE_CONF" ]]; then
+    warnx "AU-11-log-retention" "AU-11: no logrotate config found for audit logs at $LOGROTATE_CONF — configure log rotation with adequate retention"
+  else
+    ROTATE_COUNT=$(platform logrotate_rotate_count "$LOGROTATE_CONF")
+    if [[ -z "$ROTATE_COUNT" ]]; then
+      warnx "AU-11-log-retention" "AU-11: $LOGROTATE_CONF has no 'rotate' directive — retention period is undefined"
+    elif [[ "$ROTATE_COUNT" -ge 4 ]]; then
+      passx "AU-11-log-retention" "AU-11: audit logs retained for $ROTATE_COUNT rotation cycles ($LOGROTATE_CONF)"
+    else
+      warnx "AU-11-log-retention" "AU-11: audit logs retained for only $ROTATE_COUNT rotation cycles — recommend >= 4 weeks retention"
+    fi
+  fi
+fi

--- a/assessment/checks/check-ca.sh
+++ b/assessment/checks/check-ca.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# check-ca.sh — Assessment, Authorization & Monitoring (CA) — NIST 800-53 Rev 5
+# Platform-specific data acquisition lives in lib/platforms/<os>.sh.
+
+# CA-9: Internal System Connections — enumerate OpenClaw MCP server entries
+log "CA-9: Internal system connections (MCP servers)"
+CA_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    CA_OC_CONFIG="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$CA_OC_CONFIG" ]]; then
+  skipx "CA-9-mcp-connections" "CA-9: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json) — cannot enumerate MCP server connections"
+elif ! command -v python3 &>/dev/null; then
+  skipx "CA-9-mcp-connections" "CA-9: python3 not available — cannot parse $CA_OC_CONFIG for mcp.servers entries"
+else
+  MCP_SERVERS=$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+except Exception:
+    print("")
+    sys.exit(0)
+servers = (cfg.get("mcp") or {}).get("servers") or {}
+if isinstance(servers, dict):
+    names = list(servers.keys())
+elif isinstance(servers, list):
+    names = [s.get("name", "unnamed") if isinstance(s, dict) else str(s) for s in servers]
+else:
+    names = []
+print("\n".join(names))
+' "$CA_OC_CONFIG" 2>/dev/null)
+  MCP_COUNT=0
+  if [[ -n "$MCP_SERVERS" ]]; then
+    MCP_COUNT=$(echo "$MCP_SERVERS" | grep -c .)
+  fi
+  if [[ "$MCP_COUNT" -eq 0 ]]; then
+    passx "CA-9-mcp-connections" "CA-9: no MCP server connections configured in $CA_OC_CONFIG"
+  else
+    NAMES_LIST=$(echo "$MCP_SERVERS" | tr '\n' ',' | sed 's/,$//')
+    warnx "CA-9-mcp-connections" "CA-9: $MCP_COUNT MCP server connection(s) configured ($NAMES_LIST) — confirm each is documented in the system security plan / interconnection agreements"
+  fi
+fi

--- a/assessment/checks/check-cm.sh
+++ b/assessment/checks/check-cm.sh
@@ -91,3 +91,87 @@ if platform sshd_active; then
     fi
   fi
 fi
+
+# CM-3: Configuration Change Control — is ~/.openclaw under version control?
+#
+# Two acceptable signals: the config directory itself is a git working
+# tree, or Sarge's own drift-snapshot tracking (drift/snapshot.sh) has a
+# baseline recorded so unreviewed changes are at least detectable.
+log "CM-3: Configuration change control"
+CM3_SNAPSHOT_DIR="${SARGE_SNAPSHOT_DIR:-$HOME/.sarge/snapshots}"
+if [[ -d "$HOME/.openclaw/.git" ]]; then
+  passx "CM-3-change-control" "CM-3: ~/.openclaw is under version control (.git present)"
+elif [[ -e "$CM3_SNAPSHOT_DIR/latest.json" ]]; then
+  passx "CM-3-change-control" "CM-3: Sarge drift-snapshot tracking is enabled ($CM3_SNAPSHOT_DIR/latest.json found)"
+else
+  warnx "CM-3-change-control" "CM-3: ~/.openclaw is not under version control and no Sarge drift snapshot was found — run drift/snapshot.sh or git-init ~/.openclaw to track configuration changes"
+fi
+
+# CM-5: Access Restrictions for Change — OpenClaw config file ownership
+#
+# Same openclaw.json -> config.json fallback used throughout check-ac.sh /
+# check-ia.sh / check-sa.sh (issue #61).
+log "CM-5: Access restrictions for change"
+CM5_USER=$(whoami)
+CM5_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    CM5_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$CM5_OC_CONFIG" ]]; then
+  CM5_CONFIG_NAME=$(basename "$CM5_OC_CONFIG")
+  CM5_OWNER=$(platform file_owner "$CM5_OC_CONFIG")
+  if [[ "$CM5_OWNER" == "$CM5_USER" ]]; then
+    passx "CM-5-config-owner" "CM-5: $CM5_CONFIG_NAME is owned by $CM5_USER (the agent account)"
+  elif [[ "$CM5_OWNER" == "root" ]]; then
+    failx "CM-5-config-owner" "CM-5: $CM5_CONFIG_NAME is owned by root, not the agent account ($CM5_USER) — the agent account cannot manage its own configuration under least-privilege change control"
+  else
+    warnx "CM-5-config-owner" "CM-5: $CM5_CONFIG_NAME is owned by $CM5_OWNER, not the current user ($CM5_USER) — verify this is intentional"
+  fi
+else
+  skipx "CM-5-config-owner" "CM-5: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# CM-8: System Component Inventory — Node.js runtime + MCP servers + plugins
+#
+# Informational: lists what's installed so operators can reconcile against
+# an approved component list. Always PASS — absence of an inventory tool
+# (jq/python3) is noted in the message rather than escalated, matching how
+# SA-9 treats the same jq/python3 fallback (check-sa.sh).
+log "CM-8: System component inventory"
+CM8_NODE_VER=$(node --version 2>/dev/null || echo "not found")
+CM8_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    CM8_OC_CONFIG="$candidate"
+    break
+  fi
+done
+CM8_MCP_COUNT="unknown"
+CM8_PLUGIN_COUNT="unknown"
+if [[ -n "$CM8_OC_CONFIG" ]] && command -v jq &>/dev/null; then
+  CM8_MCP_COUNT=$(jq -r '(.mcp.servers // {}) | to_entries | map(select(.key | startswith("_") | not)) | length' "$CM8_OC_CONFIG" 2>/dev/null)
+  CM8_PLUGIN_COUNT=$(jq -r '(.plugins.entries // .plugins // {}) | (if type=="object" then (keys|length) elif type=="array" then length else 0 end)' "$CM8_OC_CONFIG" 2>/dev/null)
+fi
+passx "CM-8-component-inventory" "CM-8: Node.js ${CM8_NODE_VER}, ${CM8_MCP_COUNT} MCP server(s), ${CM8_PLUGIN_COUNT} plugin(s) configured — review against the approved component list"
+
+# CM-11: User-Installed Software — globally-installed npm packages
+#
+# Global npm packages sit outside the OpenClaw workspace tree and outside
+# package.json-tracked dependencies, so they're a common source of
+# unreviewed user-installed software. npm itself and anything with
+# "openclaw" in the name are expected and excluded.
+log "CM-11: User-installed software (global npm packages)"
+if command -v npm &>/dev/null; then
+  CM11_GLOBAL=$(npm list -g --depth=0 2>/dev/null | tail -n +2 | sed -E 's/^[├└──│ ]+//' | grep -vE '^\s*$')
+  CM11_UNEXPECTED=$(echo "$CM11_GLOBAL" | grep -viE '^npm@|openclaw' || true)
+  if [[ -z "$CM11_UNEXPECTED" ]]; then
+    passx "CM-11-global-npm-packages" "CM-11: No unexpected globally-installed npm packages found outside the OpenClaw tree"
+  else
+    warnx "CM-11-global-npm-packages" "CM-11: Unexpected global npm packages found — review: $(echo "$CM11_UNEXPECTED" | tr '\n' '|')"
+  fi
+else
+  skipx "CM-11-global-npm-packages" "CM-11: npm not found on PATH — global package inventory check skipped"
+fi

--- a/assessment/checks/check-cp.sh
+++ b/assessment/checks/check-cp.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# check-cp.sh — Contingency Planning (CP) — NIST 800-53 Rev 5
+# Platform-specific data acquisition lives in lib/platforms/<os>.sh.
+
+# CP-9: System Backup — cron/systemd backup mechanism + recent backup evidence
+log "CP-9: System backup"
+CP_BACKUP_FOUND=0
+CP_BACKUP_NOTE=""
+
+if command -v crontab &>/dev/null; then
+  CP_CRON_HIT=$(crontab -l 2>/dev/null | grep -Eiv "^[[:space:]]*#" | grep -i "backup" | head -1)
+  if [[ -n "$CP_CRON_HIT" ]]; then
+    CP_BACKUP_FOUND=1
+    CP_BACKUP_NOTE="${CP_BACKUP_NOTE:+$CP_BACKUP_NOTE, }crontab entry"
+  fi
+else
+  CP_CRON_UNAVAILABLE=1
+fi
+
+if command -v systemctl &>/dev/null; then
+  CP_TIMER_HIT=$(systemctl list-timers --all 2>/dev/null | grep -i "backup" | head -1)
+  if [[ -n "$CP_TIMER_HIT" ]]; then
+    CP_BACKUP_FOUND=1
+    CP_BACKUP_NOTE="${CP_BACKUP_NOTE:+$CP_BACKUP_NOTE, }systemd timer"
+  fi
+fi
+
+if [[ "$CP_BACKUP_FOUND" -eq 1 ]]; then
+  passx "CP-9-backup-mechanism" "CP-9: backup mechanism found ($CP_BACKUP_NOTE)"
+elif [[ "${CP_CRON_UNAVAILABLE:-0}" == "1" ]] && ! command -v systemctl &>/dev/null; then
+  skipx "CP-9-backup-mechanism" "CP-9: neither crontab nor systemctl available — cannot verify backup mechanism"
+else
+  warnx "CP-9-backup-mechanism" "CP-9: no backup cron entry or systemd timer found (searched for 'backup') — configure a scheduled backup of ~/.openclaw config, secrets, and workspace state"
+fi

--- a/assessment/checks/check-ia.sh
+++ b/assessment/checks/check-ia.sh
@@ -97,3 +97,149 @@ if [[ -n "$TMOUT_SET" ]]; then
 else
   warnx "IA-2-tmout-unset" "IA-2: TMOUT not set in /etc/profile or /etc/profile.d/ — recommend TMOUT=900"
 fi
+
+# IA-4: Identifier Management — UID uniqueness
+#
+# /etc/passwd exists on every platform Sarge supports (macOS keeps a local
+# copy alongside Open Directory). Duplicate UIDs mean two identifiers
+# resolve to the same authorization context — a violation of IA-4's
+# "unique identifier per user" requirement regardless of OS. No
+# platform-specific probe needed; read directly like AC-2 does.
+log "IA-4: Identifier Management (UID uniqueness)"
+if [[ -r /etc/passwd ]]; then
+  DUP_UIDS=$(awk -F: '{print $3}' /etc/passwd | sort | uniq -d)
+  if [[ -z "$DUP_UIDS" ]]; then
+    passx "IA-4-duplicate-uids" "IA-4: No duplicate UIDs in /etc/passwd — every identifier is unique"
+  else
+    failx "IA-4-duplicate-uids" "IA-4: Duplicate UIDs found in /etc/passwd (identifier reuse): $(echo "$DUP_UIDS" | tr '\n' ' ')"
+  fi
+else
+  warnx "IA-4-duplicate-uids" "IA-4: /etc/passwd not readable — cannot verify UID uniqueness"
+fi
+
+# IA-7: Cryptographic Module Authentication — SSH protocol/cipher hygiene
+log "IA-7: Cryptographic Module Authentication (SSH protocol/ciphers)"
+if ! platform_supports sshd_config_path; then
+  skipx "IA-7-ssh-protocol" "IA-7: SSH config path probe not implemented for ${SARGE_OS_DESCRIPTION}"
+else
+  SSHD_CONFIG=$(platform sshd_config_path)
+  # Same drop-in discovery as CM-7's SSH section (check-cm.sh) — first
+  # match wins under OpenSSH semantics, so a match in any file is enough.
+  _IA7_SSHD_CONF_FILES=("$SSHD_CONFIG")
+  IA7_SSHD_DROPIN_DIR="${SSHD_CONFIG%/*}/sshd_config.d"
+  if [[ -d "$IA7_SSHD_DROPIN_DIR" ]]; then
+    while IFS= read -r f; do
+      _IA7_SSHD_CONF_FILES+=("$f")
+    done < <(find "$IA7_SSHD_DROPIN_DIR" -maxdepth 1 -name '*.conf' -type f 2>/dev/null | sort)
+  fi
+  if [[ -f "$SSHD_CONFIG" ]]; then
+    if grep -qiE "^[[:space:]]*Protocol[[:space:]]+1(\b|,)" "${_IA7_SSHD_CONF_FILES[@]}" 2>/dev/null; then
+      failx "IA-7-ssh-protocol" "IA-7: SSHv1 (Protocol 1) is configured — must be SSHv2 only"
+    else
+      passx "IA-7-ssh-protocol" "IA-7: SSHv1 (Protocol 1) not configured — SSHv2 in effect"
+    fi
+
+    WEAK_CIPHERS=$(grep -iE "^[[:space:]]*Ciphers" "${_IA7_SSHD_CONF_FILES[@]}" 2>/dev/null | grep -iE "3des|arcfour|-cbc" || true)
+    if [[ -n "$WEAK_CIPHERS" ]]; then
+      failx "IA-7-ssh-weak-ciphers" "IA-7: Weak SSH cipher(s) explicitly configured: $(echo "$WEAK_CIPHERS" | tr '\n' ' ')"
+    else
+      passx "IA-7-ssh-weak-ciphers" "IA-7: No weak SSH ciphers (3des/arcfour/*-cbc) explicitly configured"
+    fi
+  else
+    skipx "IA-7-ssh-protocol" "IA-7: $SSHD_CONFIG not found — cannot verify SSH protocol/cipher configuration"
+  fi
+fi
+
+# IA-7: Cryptographic Module Authentication — gateway TLS version
+#
+# Live OpenClaw 2026.7.x writes runtime config to `openclaw.json`; older
+# installs used `config.json`. Same fallback probe as check-sc.sh's SC-28
+# section (issue #61) so long-lived hosts don't get a spurious SKIP.
+log "IA-7: Cryptographic Module Authentication (gateway TLS)"
+IA_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    IA_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$IA_OC_CONFIG" ]]; then
+  IA_CONFIG_NAME=$(basename "$IA_OC_CONFIG")
+  if grep -qiE '"(minVersion|min_version)"[[:space:]]*:[[:space:]]*"TLSv?1\.[01]"' "$IA_OC_CONFIG" 2>/dev/null; then
+    failx "IA-7-gateway-tls-version" "IA-7: OpenClaw gateway TLS minVersion allows TLSv1.0/1.1 in $IA_CONFIG_NAME — set to TLSv1.2 or higher"
+  elif grep -qiE '"tls"' "$IA_OC_CONFIG" 2>/dev/null; then
+    passx "IA-7-gateway-tls-version" "IA-7: OpenClaw gateway TLS is configured in $IA_CONFIG_NAME — no TLSv1.0/1.1 minVersion detected"
+  else
+    warnx "IA-7-gateway-tls-version" "IA-7: No explicit TLS configuration found in $IA_CONFIG_NAME — verify the TLS terminator (e.g. Cloudflare Tunnel) enforces TLSv1.2+"
+  fi
+else
+  skipx "IA-7-gateway-tls-version" "IA-7: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# IA-8: Identification and Authentication (Non-Organizational Users)
+#
+# External/anonymous channel users (Discord, Telegram, etc.) must be
+# identified before the gateway extends any trust. Sarge can't see
+# per-message auth at the OS layer, so this checks the config-level
+# controls: an explicit auth mode, registered providers, and that
+# anonymous access isn't left wide open.
+log "IA-8: Identification and Authentication (Non-Org Users)"
+IA_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    IA_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$IA_OC_CONFIG" ]]; then
+  IA_CONFIG_NAME=$(basename "$IA_OC_CONFIG")
+  AUTH_MODE=$(grep -oE '"mode"[[:space:]]*:[[:space:]]*"[^"]*"' "$IA_OC_CONFIG" 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+  if [[ -n "$AUTH_MODE" ]]; then
+    passx "IA-8-auth-mode" "IA-8: $IA_CONFIG_NAME declares an auth.mode ($AUTH_MODE) for external/channel users"
+  else
+    warnx "IA-8-auth-mode" "IA-8: No auth.mode found in $IA_CONFIG_NAME — verify external channel users are identified before gateway trust"
+  fi
+
+  if grep -qiE '"anonymous"[[:space:]]*:[[:space:]]*true' "$IA_OC_CONFIG" 2>/dev/null; then
+    failx "IA-8-anonymous-access" "IA-8: Anonymous access is enabled in $IA_CONFIG_NAME — non-org users are not authenticated before gateway trust"
+  else
+    passx "IA-8-anonymous-access" "IA-8: Anonymous access is not enabled in $IA_CONFIG_NAME"
+  fi
+
+  if grep -qE '"providers"' "$IA_OC_CONFIG" 2>/dev/null; then
+    passx "IA-8-auth-providers" "IA-8: auth.providers configured in $IA_CONFIG_NAME"
+  else
+    warnx "IA-8-auth-providers" "IA-8: No auth.providers found in $IA_CONFIG_NAME — external channel identities may not be mapped to allowlisted users"
+  fi
+else
+  skipx "IA-8-auth-mode" "IA-8: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# IA-11: Re-authentication — gateway session idle timeout
+#
+# mcp.sessionIdleTtlMs (and equivalents) bound how long a session can sit
+# idle before it must re-authenticate. Missing = never expires; 0 =
+# explicitly disabled/infinite. Both are IA-11 gaps.
+log "IA-11: Re-authentication (session idle timeout)"
+IA_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    IA_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$IA_OC_CONFIG" ]]; then
+  IA_CONFIG_NAME=$(basename "$IA_OC_CONFIG")
+  IDLE_TTL=$(grep -oE '"sessionIdleTtlMs"[[:space:]]*:[[:space:]]*[0-9]+' "$IA_OC_CONFIG" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+  if [[ -z "$IDLE_TTL" ]]; then
+    warnx "IA-11-session-idle-ttl" "IA-11: mcp.sessionIdleTtlMs not set in $IA_CONFIG_NAME — sessions may never require re-authentication"
+  elif [[ "$IDLE_TTL" -eq 0 ]]; then
+    failx "IA-11-session-idle-ttl" "IA-11: mcp.sessionIdleTtlMs is 0 (infinite/disabled) in $IA_CONFIG_NAME — require periodic re-authentication"
+  elif [[ "$IDLE_TTL" -le 86400000 ]]; then
+    passx "IA-11-session-idle-ttl" "IA-11: mcp.sessionIdleTtlMs is ${IDLE_TTL}ms (<=24h) in $IA_CONFIG_NAME"
+  else
+    warnx "IA-11-session-idle-ttl" "IA-11: mcp.sessionIdleTtlMs is ${IDLE_TTL}ms (>24h) in $IA_CONFIG_NAME — consider a shorter re-authentication window"
+  fi
+else
+  skipx "IA-11-session-idle-ttl" "IA-11: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi

--- a/assessment/checks/check-mp.sh
+++ b/assessment/checks/check-mp.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# check-mp.sh — Media Protection (MP) checks — NIST 800-53 Rev 5
+# Platform-specific data acquisition lives in lib/platforms/<os>.sh.
+
+# MP-6: Media Sanitization
+#
+# OpenClaw's `media.ttlHours` governs how long generated/received media
+# (images, audio, video, downloads) sits on disk before cleanup. Without
+# a TTL, media accumulates indefinitely — the agent-equivalent of media
+# that's never sanitized. `media.maxSizeMb` is a secondary indicator:
+# even with a TTL configured, an unbounded max size means a burst of
+# large media can sit at rest for the full TTL window.
+log "MP-6: Media sanitization (retention TTL)"
+
+# Live OpenClaw 2026.7.x writes runtime config to `openclaw.json`. Older
+# installs (pre-2026.4) used `config.json`. Same fallback probe used by
+# check-sc.sh / check-ia.sh (issue #61).
+MP_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    MP_OC_CONFIG="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$MP_OC_CONFIG" ]]; then
+  MP_CONFIG_NAME=$(basename "$MP_OC_CONFIG")
+
+  TTL_HOURS=$(grep -oE '"ttlHours"[[:space:]]*:[[:space:]]*[0-9]+' "$MP_OC_CONFIG" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+  if [[ -z "$TTL_HOURS" ]]; then
+    warnx "MP-6-media-ttl" "MP-6: media.ttlHours not set in $MP_CONFIG_NAME — generated/received media is retained indefinitely; set a retention window"
+  elif [[ "$TTL_HOURS" -eq 0 ]]; then
+    warnx "MP-6-media-ttl" "MP-6: media.ttlHours is 0 (disabled) in $MP_CONFIG_NAME — media is never sanitized"
+  else
+    passx "MP-6-media-ttl" "MP-6: media.ttlHours is ${TTL_HOURS}h in $MP_CONFIG_NAME"
+  fi
+
+  # Secondary indicator: media.maxSizeMb
+  MAX_SIZE=$(grep -oE '"maxSizeMb"[[:space:]]*:[[:space:]]*[0-9]+' "$MP_OC_CONFIG" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+  if [[ -n "$MAX_SIZE" ]]; then
+    passx "MP-6-media-max-size" "MP-6: media.maxSizeMb is set to ${MAX_SIZE}MB in $MP_CONFIG_NAME"
+  else
+    warnx "MP-6-media-max-size" "MP-6: media.maxSizeMb not set in $MP_CONFIG_NAME — no upper bound on stored media size"
+  fi
+else
+  skipx "MP-6-media-ttl" "MP-6: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi

--- a/assessment/checks/check-ra.sh
+++ b/assessment/checks/check-ra.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# check-ra.sh — Risk Assessment (RA) checks — NIST 800-53 Rev 5
+# Platform-specific data acquisition lives in lib/platforms/<os>.sh.
+
+# RA-5: Vulnerability Monitoring and Scanning
+#
+# Checks for evidence that vulnerability scanning is configured and recent.
+# On an OpenClaw agent host, this means:
+#   1. apt security-audit tools are installed (apt-get, unattended-upgrades)
+#   2. A vulnerability scanner is present (trivy, grype, or OS-level tools)
+#   3. Recent scan evidence exists (scan output files, last-run timestamps)
+#   4. OpenClaw npm dependencies have been audited recently
+log "RA-5: Vulnerability monitoring and scanning"
+
+# RA-5 sub-check 1: OS-level vulnerability scanner installed
+RA5_SCANNER_FOUND=0
+RA5_SCANNER_NAME=""
+for scanner in trivy grype oscap lynis debsecan; do
+  if command -v "$scanner" &>/dev/null; then
+    RA5_SCANNER_FOUND=1
+    RA5_SCANNER_NAME="${RA5_SCANNER_NAME}${RA5_SCANNER_NAME:+, }$scanner"
+  fi
+done
+if [[ "$RA5_SCANNER_FOUND" -eq 1 ]]; then
+  passx "RA-5-scanner-installed" "RA-5: Vulnerability scanner(s) installed: $RA5_SCANNER_NAME"
+else
+  warnx "RA-5-scanner-installed" "RA-5: No recognized vulnerability scanner found (checked: trivy, grype, oscap, lynis, debsecan) — install one to enable automated vulnerability scanning"
+fi
+
+# RA-5 sub-check 2: Recent scan evidence
+RA5_SCAN_EVIDENCE=0
+RA5_EVIDENCE_NOTE=""
+RA5_SCAN_DIRS=(
+  "$HOME/.openclaw/scans"
+  "$HOME/.openclaw/reports"
+  "/var/log/trivy"
+  "/var/log/lynis"
+  "/var/lib/oscap"
+)
+for scan_dir in "${RA5_SCAN_DIRS[@]}"; do
+  if [[ -d "$scan_dir" ]]; then
+    RA5_RECENT=$(find "$scan_dir" -maxdepth 2 -type f \( -name "*.json" -o -name "*.html" -o -name "*.xml" -o -name "*.txt" \) -mtime -30 2>/dev/null | head -1)
+    if [[ -n "$RA5_RECENT" ]]; then
+      RA5_SCAN_EVIDENCE=1
+      RA5_EVIDENCE_NOTE="${RA5_EVIDENCE_NOTE}${RA5_EVIDENCE_NOTE:+, }$scan_dir"
+    fi
+  fi
+done
+# Also check for Sarge's own report output
+SARGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RA5_SARGE_REPORT=$(find "$SARGE_DIR" -maxdepth 3 -name "report.json" -mtime -30 2>/dev/null | head -1)
+if [[ -n "$RA5_SARGE_REPORT" ]]; then
+  RA5_SCAN_EVIDENCE=1
+  RA5_EVIDENCE_NOTE="${RA5_EVIDENCE_NOTE}${RA5_EVIDENCE_NOTE:+, }sarge report"
+fi
+
+if [[ "$RA5_SCAN_EVIDENCE" -eq 1 ]]; then
+  passx "RA-5-scan-evidence" "RA-5: Recent scan evidence found (within 30 days) in: $RA5_EVIDENCE_NOTE"
+else
+  warnx "RA-5-scan-evidence" "RA-5: No recent vulnerability scan output found (checked ~/.openclaw/scans, /var/log/trivy, /var/log/lynis, /var/lib/oscap, sarge reports) — run a vulnerability scan and store results"
+fi
+
+# RA-5 sub-check 3: npm audit for OpenClaw dependencies
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  RA5_OC_INSTALL=""
+  for candidate in /usr/lib/node_modules/openclaw /usr/local/lib/node_modules/openclaw "$HOME/.npm-global/lib/node_modules/openclaw"; do
+    if [[ -d "$candidate" && -f "$candidate/package.json" ]]; then
+      RA5_OC_INSTALL="$candidate"
+      break
+    fi
+  done
+  if [[ -n "$RA5_OC_INSTALL" ]] && command -v npm &>/dev/null; then
+    RA5_AUDIT_OUTPUT=$(cd "$RA5_OC_INSTALL" && npm audit --json 2>/dev/null)
+    if [[ -n "$RA5_AUDIT_OUTPUT" ]]; then
+      RA5_VULN_COUNT=$(echo "$RA5_AUDIT_OUTPUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    meta = d.get("metadata", {}).get("vulnerabilities", {})
+    total = meta.get("total", 0)
+    if total == 0:
+        total = meta.get("high", 0) + meta.get("critical", 0) + meta.get("moderate", 0) + meta.get("low", 0)
+    print(total)
+except Exception:
+    print("-1")
+' 2>/dev/null)
+      RA5_CRIT_COUNT=$(echo "$RA5_AUDIT_OUTPUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    meta = d.get("metadata", {}).get("vulnerabilities", {})
+    print(meta.get("critical", 0) + meta.get("high", 0))
+except Exception:
+    print("-1")
+' 2>/dev/null)
+      if [[ "$RA5_VULN_COUNT" == "0" ]]; then
+        passx "RA-5-npm-audit" "RA-5: npm audit reports 0 known vulnerabilities in OpenClaw dependencies"
+      elif [[ "$RA5_CRIT_COUNT" -gt 0 ]]; then
+        failx "RA-5-npm-audit" "RA-5: npm audit found $RA5_VULN_COUNT vulnerabilities ($RA5_CRIT_COUNT critical/high) in OpenClaw dependencies at $RA5_OC_INSTALL — run 'npm audit fix'"
+      elif [[ "$RA5_VULN_COUNT" -gt 0 ]]; then
+        warnx "RA-5-npm-audit" "RA-5: npm audit found $RA5_VULN_COUNT vulnerabilities (none critical/high) in OpenClaw dependencies at $RA5_OC_INSTALL — review and remediate"
+      else
+        skipx "RA-5-npm-audit" "RA-5: npm audit output could not be parsed — run 'npm audit' manually in $RA5_OC_INSTALL"
+      fi
+    else
+      skipx "RA-5-npm-audit" "RA-5: npm audit returned no output for $RA5_OC_INSTALL — may require 'npm install' first"
+    fi
+  elif [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+    skipx "RA-5-npm-audit" "RA-5: OpenClaw npm installation not found at standard paths, or npm not available — cannot run dependency audit"
+  fi
+fi
+
+# RA-5 sub-check 4: OS package security updates pending (distinct from CM-6 —
+# this checks specifically for CVE-tagged security updates)
+if platform_supports pending_security_updates_count; then
+  RA5_SEC_UPDATES=$(platform pending_security_updates_count)
+  if [[ "$RA5_SEC_UPDATES" -eq 0 ]]; then
+    passx "RA-5-os-security-patches" "RA-5: No pending OS security patches"
+  else
+    warnx "RA-5-os-security-patches" "RA-5: $RA5_SEC_UPDATES OS security update(s) pending — apply to close known vulnerabilities"
+  fi
+else
+  skipx "RA-5-os-security-patches" "RA-5: Security update counting not available on ${SARGE_OS_DESCRIPTION}"
+fi

--- a/assessment/checks/check-sa.sh
+++ b/assessment/checks/check-sa.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# check-sa.sh — System & Services Acquisition (SA) checks — NIST 800-53 Rev 5
+# Platform-specific data acquisition lives in lib/platforms/<os>.sh.
+
+# SA-9: External System Services
+#
+# Enumerates external MCP servers / API dependencies declared under
+# `mcp.servers` in the live OpenClaw config. Presence of external services
+# isn't itself a finding (agents legitimately call out to MCP servers) —
+# this is an informational WARN so the list surfaces for manual review of
+# data-sharing agreements and supply-chain exposure, matching how AS-7 /
+# check-as.sh treats primitive-presence as WARN rather than FAIL.
+log "SA-9: External system services (MCP servers)"
+
+# Live OpenClaw 2026.7.x writes runtime config to `openclaw.json`. Older
+# installs (pre-2026.4) used `config.json`. Same fallback probe used by
+# check-sc.sh / check-ia.sh (issue #61).
+SA_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    SA_OC_CONFIG="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$SA_OC_CONFIG" ]]; then
+  SA_CONFIG_NAME=$(basename "$SA_OC_CONFIG")
+  if command -v jq &>/dev/null; then
+    MCP_SERVERS=$(jq -r '(.mcp.servers // {}) | to_entries[] | select(.key | startswith("_") | not) | .key + " -> " + (.value.url? // "no url")' "$SA_OC_CONFIG" 2>/dev/null)
+    MCP_COUNT=$(echo "$MCP_SERVERS" | grep -c . 2>/dev/null || echo 0)
+  elif command -v python3 &>/dev/null; then
+    MCP_SERVERS=$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    servers = (d.get("mcp") or {}).get("servers") or {}
+    for k, v in servers.items():
+        if k.startswith("_"):
+            continue
+        url = v.get("url", "no url") if isinstance(v, dict) else "no url"
+        print(f"{k} -> {url}")
+except Exception:
+    pass
+' "$SA_OC_CONFIG" 2>/dev/null)
+    MCP_COUNT=$(echo "$MCP_SERVERS" | grep -c . 2>/dev/null || echo 0)
+  else
+    MCP_SERVERS=""
+    MCP_COUNT=""
+  fi
+
+  if [[ -z "$MCP_COUNT" ]]; then
+    warnx "SA-9-external-mcp-servers" "SA-9: neither jq nor python3 available — cannot enumerate mcp.servers in $SA_CONFIG_NAME"
+  elif [[ "$MCP_COUNT" -gt 0 ]]; then
+    warnx "SA-9-external-mcp-servers" "SA-9: $MCP_COUNT external MCP server(s)/API dependencies configured in $SA_CONFIG_NAME — review each for data-sharing agreements and supply-chain risk: $(echo "$MCP_SERVERS" | tr '\n' '|')"
+  else
+    passx "SA-9-external-mcp-servers" "SA-9: no external MCP servers configured in $SA_CONFIG_NAME"
+  fi
+else
+  skipx "SA-9-external-mcp-servers" "SA-9: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# SA-22: Unsupported System Components — Ubuntu release EOL
+#
+# Ubuntu LTS EOL dates (standard support, not ESM): 20.04 Apr 2025,
+# 22.04 Apr 2027, 24.04 Apr 2029, 26.04 Apr 2031. FAIL past EOL, WARN
+# inside the 6-month glidepath, PASS otherwise. Ubuntu-only lookup table
+# by design (see task scope) — SARGE_OS_VERSION is populated for macOS
+# too but the EOL table doesn't apply there.
+log "SA-22: Operating system support status (Ubuntu EOL)"
+if [[ "$SARGE_OS" == "ubuntu" ]]; then
+  UBUNTU_EOL=""
+  case "$SARGE_OS_VERSION" in
+    20.04) UBUNTU_EOL="2025-04-01" ;;
+    22.04) UBUNTU_EOL="2027-04-01" ;;
+    24.04) UBUNTU_EOL="2029-04-01" ;;
+    26.04) UBUNTU_EOL="2031-04-01" ;;
+  esac
+  if [[ -z "$UBUNTU_EOL" ]]; then
+    warnx "SA-22-ubuntu-eol" "SA-22: no known EOL date for Ubuntu ${SARGE_OS_VERSION} — verify support status at https://endoflife.date/ubuntu"
+  else
+    NOW_EPOCH=$(date +%s)
+    EOL_EPOCH=$(date -d "$UBUNTU_EOL" +%s 2>/dev/null)
+    WARN_EPOCH=$(date -d "$UBUNTU_EOL -6 months" +%s 2>/dev/null)
+    if [[ -z "$EOL_EPOCH" || -z "$WARN_EPOCH" ]]; then
+      warnx "SA-22-ubuntu-eol" "SA-22: could not compute EOL date for Ubuntu ${SARGE_OS_VERSION} — verify support status at https://endoflife.date/ubuntu"
+    elif [[ "$NOW_EPOCH" -ge "$EOL_EPOCH" ]]; then
+      failx "SA-22-ubuntu-eol" "SA-22: Ubuntu ${SARGE_OS_VERSION} reached end-of-life on ${UBUNTU_EOL} — upgrade to a supported LTS release"
+    elif [[ "$NOW_EPOCH" -ge "$WARN_EPOCH" ]]; then
+      warnx "SA-22-ubuntu-eol" "SA-22: Ubuntu ${SARGE_OS_VERSION} reaches end-of-life on ${UBUNTU_EOL} (within 6 months) — plan an upgrade"
+    else
+      passx "SA-22-ubuntu-eol" "SA-22: Ubuntu ${SARGE_OS_VERSION} is supported until ${UBUNTU_EOL}"
+    fi
+  fi
+else
+  skipx "SA-22-ubuntu-eol" "SA-22: Ubuntu EOL lookup table does not apply on ${SARGE_OS_DESCRIPTION}"
+fi
+
+# SA-22: Unsupported System Components — Node.js runtime EOL
+#
+# Node.js EOL dates: 18 Apr 2025, 20 Apr 2026, 22 Apr 2027, 24 Apr 2028.
+# Same FAIL/WARN/PASS glidepath as the Ubuntu check above.
+log "SA-22: Node.js runtime support status"
+if command -v node &>/dev/null; then
+  NODE_VER=$(node --version 2>/dev/null | tr -d 'v')
+  NODE_MAJOR="${NODE_VER%%.*}"
+  NODE_EOL=""
+  case "$NODE_MAJOR" in
+    18) NODE_EOL="2025-04-30" ;;
+    20) NODE_EOL="2026-04-30" ;;
+    22) NODE_EOL="2027-04-30" ;;
+    24) NODE_EOL="2028-04-30" ;;
+  esac
+  if [[ -z "$NODE_EOL" ]]; then
+    warnx "SA-22-node-eol" "SA-22: no known EOL date for Node.js ${NODE_VER:-unknown} (major ${NODE_MAJOR:-unknown}) — verify support status at https://endoflife.date/nodejs"
+  else
+    NOW_EPOCH=$(date +%s)
+    EOL_EPOCH=$(date -d "$NODE_EOL" +%s 2>/dev/null)
+    WARN_EPOCH=$(date -d "$NODE_EOL -6 months" +%s 2>/dev/null)
+    if [[ -z "$EOL_EPOCH" || -z "$WARN_EPOCH" ]]; then
+      warnx "SA-22-node-eol" "SA-22: could not compute EOL date for Node.js ${NODE_VER} — verify support status at https://endoflife.date/nodejs"
+    elif [[ "$NOW_EPOCH" -ge "$EOL_EPOCH" ]]; then
+      failx "SA-22-node-eol" "SA-22: Node.js ${NODE_VER} (major $NODE_MAJOR) reached end-of-life on ${NODE_EOL} — upgrade to a supported LTS release"
+    elif [[ "$NOW_EPOCH" -ge "$WARN_EPOCH" ]]; then
+      warnx "SA-22-node-eol" "SA-22: Node.js ${NODE_VER} reaches end-of-life on ${NODE_EOL} (within 6 months) — plan an upgrade"
+    else
+      passx "SA-22-node-eol" "SA-22: Node.js ${NODE_VER} is supported until ${NODE_EOL}"
+    fi
+  fi
+else
+  skipx "SA-22-node-eol" "SA-22: node not found on PATH — Node.js runtime EOL check skipped"
+fi

--- a/assessment/checks/check-sc.sh
+++ b/assessment/checks/check-sc.sh
@@ -71,3 +71,117 @@ if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
     fi
   fi
 fi
+
+# SC-2: Application Partitioning — OpenClaw process isolation
+log "SC-2: Application partitioning"
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  SC2_OC_PID=$(pgrep -f "openclaw" 2>/dev/null | head -1)
+  if [[ -n "$SC2_OC_PID" ]]; then
+    SC2_OC_USER=$(ps -o user= -p "$SC2_OC_PID" 2>/dev/null | tr -d ' ')
+    SC2_CURRENT=$(whoami)
+    if [[ "$SC2_OC_USER" == "root" ]]; then
+      failx "SC-2-process-isolation" "SC-2: OpenClaw is running as root (PID $SC2_OC_PID) — run under a dedicated non-root service account"
+    else
+      passx "SC-2-process-isolation" "SC-2: OpenClaw is running as $SC2_OC_USER (PID $SC2_OC_PID) — not root"
+    fi
+    if [[ -d "/proc/$SC2_OC_PID/ns" ]]; then
+      SC2_PID1_MNT=$(readlink /proc/1/ns/mnt 2>/dev/null)
+      SC2_OC_MNT=$(readlink "/proc/$SC2_OC_PID/ns/mnt" 2>/dev/null)
+      if [[ -n "$SC2_PID1_MNT" && -n "$SC2_OC_MNT" && "$SC2_PID1_MNT" != "$SC2_OC_MNT" ]]; then
+        passx "SC-2-namespace-isolation" "SC-2: OpenClaw process has a separate mount namespace — container or namespace isolation detected"
+      else
+        warnx "SC-2-namespace-isolation" "SC-2: OpenClaw shares the host mount namespace — consider running in a container or with namespace isolation"
+      fi
+    fi
+  else
+    skipx "SC-2-process-isolation" "SC-2: No running OpenClaw process found — cannot verify process isolation"
+  fi
+else
+  skipx "SC-2-process-isolation" "SC-2: host-only mode — OpenClaw process checks skipped"
+fi
+
+# SC-4: Information in Shared Resources — /tmp and shared memory cleanup
+log "SC-4: Information in shared resources"
+SC4_TMP_OC_FILES=$(find /tmp -maxdepth 2 -name "*openclaw*" -o -name "*claude*" 2>/dev/null | wc -l)
+if [[ "$SC4_TMP_OC_FILES" -gt 10 ]]; then
+  warnx "SC-4-tmp-residual" "SC-4: $SC4_TMP_OC_FILES OpenClaw/Claude temp files found in /tmp — residual session data may contain sensitive information; configure periodic cleanup"
+elif [[ "$SC4_TMP_OC_FILES" -gt 0 ]]; then
+  passx "SC-4-tmp-residual" "SC-4: $SC4_TMP_OC_FILES OpenClaw/Claude temp file(s) in /tmp — within normal range"
+else
+  passx "SC-4-tmp-residual" "SC-4: No OpenClaw/Claude residual files found in /tmp"
+fi
+SC4_SHM_FILES=$(find /dev/shm -maxdepth 1 -type f 2>/dev/null | wc -l)
+if [[ "$SC4_SHM_FILES" -gt 0 ]]; then
+  warnx "SC-4-shm-residual" "SC-4: $SC4_SHM_FILES file(s) in /dev/shm — review for sensitive data residue"
+else
+  passx "SC-4-shm-residual" "SC-4: No files in /dev/shm"
+fi
+
+# SC-12: Cryptographic Key Establishment and Management
+log "SC-12: Cryptographic key management"
+SC12_SECRETS_DIR="$HOME/.openclaw/secrets"
+if [[ -d "$SC12_SECRETS_DIR" ]]; then
+  SC12_KEY_COUNT=0
+  SC12_BAD_PERM=""
+  while IFS= read -r -d '' kf; do
+    SC12_KEY_COUNT=$((SC12_KEY_COUNT + 1))
+    KF_PERM=$(platform file_perm "$kf")
+    if [[ "$KF_PERM" != "600" && "$KF_PERM" != "400" ]]; then
+      SC12_BAD_PERM="${SC12_BAD_PERM}${SC12_BAD_PERM:+, }$(basename "$kf"):$KF_PERM"
+    fi
+  done < <(find "$SC12_SECRETS_DIR" -maxdepth 1 -type f \( -name "*.key" -o -name "*.pem" -o -name "*.p12" -o -name "*-key" -o -name "*-token" -o -name "*-secret" -o -name "*.env" \) -print0 2>/dev/null)
+  if [[ "$SC12_KEY_COUNT" -eq 0 ]]; then
+    passx "SC-12-key-permissions" "SC-12: No key/credential files found in $SC12_SECRETS_DIR (or using non-file-based key management)"
+  elif [[ -z "$SC12_BAD_PERM" ]]; then
+    passx "SC-12-key-permissions" "SC-12: All $SC12_KEY_COUNT key/credential file(s) in secrets/ have restricted permissions (600 or 400)"
+  else
+    failx "SC-12-key-permissions" "SC-12: Key/credential files with weak permissions: $SC12_BAD_PERM — should be 600 or 400"
+  fi
+else
+  skipx "SC-12-key-permissions" "SC-12: No secrets directory at ~/.openclaw/secrets"
+fi
+SC12_SSH_DIR="$HOME/.ssh"
+if [[ -d "$SC12_SSH_DIR" ]]; then
+  SC12_SSH_BAD=""
+  while IFS= read -r -d '' sk; do
+    SK_PERM=$(platform file_perm "$sk")
+    if [[ "$SK_PERM" != "600" && "$SK_PERM" != "400" ]]; then
+      SC12_SSH_BAD="${SC12_SSH_BAD}${SC12_SSH_BAD:+, }$(basename "$sk"):$SK_PERM"
+    fi
+  done < <(find "$SC12_SSH_DIR" -maxdepth 1 -type f -name "id_*" ! -name "*.pub" -print0 2>/dev/null)
+  if [[ -z "$SC12_SSH_BAD" ]]; then
+    passx "SC-12-ssh-key-permissions" "SC-12: SSH private keys in ~/.ssh have restricted permissions"
+  else
+    failx "SC-12-ssh-key-permissions" "SC-12: SSH private keys with weak permissions: $SC12_SSH_BAD — should be 600"
+  fi
+else
+  skipx "SC-12-ssh-key-permissions" "SC-12: No ~/.ssh directory found"
+fi
+
+# SC-13: Cryptographic Protection — TLS and cipher configuration
+log "SC-13: Cryptographic protection"
+SC13_OPENSSL_VER=$(openssl version 2>/dev/null)
+if [[ -n "$SC13_OPENSSL_VER" ]]; then
+  SC13_MAJOR=$(echo "$SC13_OPENSSL_VER" | grep -oE '[0-9]+\.[0-9]+' | head -1)
+  case "$SC13_MAJOR" in
+    3.*|1.1)
+      passx "SC-13-openssl-version" "SC-13: $SC13_OPENSSL_VER — FIPS-capable version"
+      ;;
+    *)
+      warnx "SC-13-openssl-version" "SC-13: $SC13_OPENSSL_VER — review if this version meets organizational cryptographic requirements"
+      ;;
+  esac
+else
+  warnx "SC-13-openssl-version" "SC-13: openssl not found on PATH — cannot verify cryptographic library version"
+fi
+SC13_NODE_VER=$(node --version 2>/dev/null)
+if [[ -n "$SC13_NODE_VER" ]]; then
+  SC13_NODE_MAJOR=$(echo "$SC13_NODE_VER" | grep -oE '[0-9]+' | head -1)
+  if [[ "$SC13_NODE_MAJOR" -ge 18 ]]; then
+    passx "SC-13-node-tls" "SC-13: Node.js $SC13_NODE_VER uses OpenSSL 3.x by default (TLS 1.2+ enforced)"
+  else
+    warnx "SC-13-node-tls" "SC-13: Node.js $SC13_NODE_VER — versions below 18 may not enforce TLS 1.2+ by default"
+  fi
+else
+  skipx "SC-13-node-tls" "SC-13: Node.js not found on PATH"
+fi

--- a/assessment/checks/check-sc.sh
+++ b/assessment/checks/check-sc.sh
@@ -185,3 +185,145 @@ if [[ -n "$SC13_NODE_VER" ]]; then
 else
   skipx "SC-13-node-tls" "SC-13: Node.js not found on PATH"
 fi
+
+# SC-15: Collaborative Computing Devices — camera/microphone access
+log "SC-15: Collaborative computing devices"
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  SC15_OC_CONFIG=""
+  for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+    if [[ -f "$candidate" ]]; then
+      SC15_OC_CONFIG="$candidate"
+      break
+    fi
+  done
+  if [[ -n "$SC15_OC_CONFIG" ]]; then
+    SC15_CONFIG_NAME=$(basename "$SC15_OC_CONFIG")
+    SC15_CAMERA=$(grep -oE '"camera"[[:space:]]*:[[:space:]]*(true|false|"[^"]*")' "$SC15_OC_CONFIG" 2>/dev/null | head -1)
+    SC15_MIC=$(grep -oE '"microphone"[[:space:]]*:[[:space:]]*(true|false|"[^"]*")' "$SC15_OC_CONFIG" 2>/dev/null | head -1)
+    SC15_SCREEN=$(grep -oE '"screen"[[:space:]]*:[[:space:]]*(true|false|"[^"]*")' "$SC15_OC_CONFIG" 2>/dev/null | head -1)
+    SC15_ANY_FOUND=0
+    if [[ -n "$SC15_CAMERA" || -n "$SC15_MIC" || -n "$SC15_SCREEN" ]]; then
+      SC15_ANY_FOUND=1
+    fi
+    if [[ "$SC15_ANY_FOUND" -eq 1 ]]; then
+      SC15_DETAIL=""
+      [[ -n "$SC15_CAMERA" ]] && SC15_DETAIL="camera=$SC15_CAMERA"
+      [[ -n "$SC15_MIC" ]] && SC15_DETAIL="${SC15_DETAIL:+$SC15_DETAIL, }mic=$SC15_MIC"
+      [[ -n "$SC15_SCREEN" ]] && SC15_DETAIL="${SC15_DETAIL:+$SC15_DETAIL, }screen=$SC15_SCREEN"
+      warnx "SC-15-device-access" "SC-15: Collaborative device capabilities configured in $SC15_CONFIG_NAME ($SC15_DETAIL) — confirm each is authorized for this agent's mission"
+    else
+      passx "SC-15-device-access" "SC-15: No camera/microphone/screen capture capabilities detected in $SC15_CONFIG_NAME"
+    fi
+  else
+    skipx "SC-15-device-access" "SC-15: OpenClaw config not found — cannot check device capability grants"
+  fi
+  if command -v v4l2-ctl &>/dev/null; then
+    SC15_V4L_DEVS=$(v4l2-ctl --list-devices 2>/dev/null | grep -c "^[^ ]")
+    if [[ "$SC15_V4L_DEVS" -gt 0 ]]; then
+      warnx "SC-15-video-devices" "SC-15: $SC15_V4L_DEVS video capture device(s) detected on host — verify agent access is intentional"
+    else
+      passx "SC-15-video-devices" "SC-15: No video capture devices detected"
+    fi
+  elif [[ -e /dev/video0 ]]; then
+    warnx "SC-15-video-devices" "SC-15: /dev/video0 exists — video capture hardware is present; verify agent access is intentional"
+  else
+    passx "SC-15-video-devices" "SC-15: No /dev/video* devices found"
+  fi
+else
+  skipx "SC-15-device-access" "SC-15: host-only mode — device capability checks skipped"
+fi
+
+# SC-23: Session Authenticity — OpenClaw auth and session token configuration
+log "SC-23: Session authenticity"
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  SC23_OC_CONFIG=""
+  for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+    if [[ -f "$candidate" ]]; then
+      SC23_OC_CONFIG="$candidate"
+      break
+    fi
+  done
+  if [[ -n "$SC23_OC_CONFIG" ]]; then
+    SC23_CONFIG_NAME=$(basename "$SC23_OC_CONFIG")
+    SC23_AUTH_ENABLED=$(python3 -c '
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+    auth = cfg.get("auth", {})
+    if isinstance(auth, dict):
+        val = auth.get("enabled")
+        if val is not None:
+            print(str(val).lower())
+        else:
+            print("unset")
+    else:
+        print("unset")
+except Exception:
+    print("error")
+' "$SC23_OC_CONFIG" 2>/dev/null)
+    case "$SC23_AUTH_ENABLED" in
+      true)
+        passx "SC-23-auth-enabled" "SC-23: Authentication is enabled in $SC23_CONFIG_NAME"
+        ;;
+      false)
+        failx "SC-23-auth-enabled" "SC-23: auth.enabled is false in $SC23_CONFIG_NAME — sessions are unauthenticated"
+        ;;
+      unset)
+        warnx "SC-23-auth-enabled" "SC-23: auth.enabled not explicitly set in $SC23_CONFIG_NAME — verify the default behavior authenticates sessions"
+        ;;
+      *)
+        skipx "SC-23-auth-enabled" "SC-23: Could not parse auth configuration in $SC23_CONFIG_NAME"
+        ;;
+    esac
+    SC23_GATEWAY_TOKEN=$(grep -oE '"gatewayToken"[[:space:]]*:[[:space:]]*"[^"]*"' "$SC23_OC_CONFIG" 2>/dev/null | head -1)
+    if [[ -n "$SC23_GATEWAY_TOKEN" ]]; then
+      passx "SC-23-gateway-token" "SC-23: gatewayToken is configured in $SC23_CONFIG_NAME"
+    else
+      warnx "SC-23-gateway-token" "SC-23: No gatewayToken found in $SC23_CONFIG_NAME — gateway API may be accessible without a token"
+    fi
+  else
+    skipx "SC-23-auth-enabled" "SC-23: OpenClaw config not found — cannot check session authenticity settings"
+  fi
+else
+  skipx "SC-23-auth-enabled" "SC-23: host-only mode — session authenticity checks skipped"
+fi
+
+# SC-39: Process Isolation — cgroup and namespace enforcement
+log "SC-39: Process isolation"
+if [[ "${SARGE_HOST_ONLY:-0}" != "1" ]]; then
+  SC39_OC_PID=$(pgrep -f "openclaw" 2>/dev/null | head -1)
+  if [[ -n "$SC39_OC_PID" ]]; then
+    SC39_CGROUP=$(cat "/proc/$SC39_OC_PID/cgroup" 2>/dev/null | head -1)
+    if [[ -n "$SC39_CGROUP" ]]; then
+      if echo "$SC39_CGROUP" | grep -qE "docker|containerd|lxc|podman|systemd.*scope"; then
+        passx "SC-39-cgroup-isolation" "SC-39: OpenClaw process is in a scoped cgroup ($SC39_CGROUP) — container or systemd isolation active"
+      else
+        warnx "SC-39-cgroup-isolation" "SC-39: OpenClaw process cgroup ($SC39_CGROUP) does not indicate container isolation — consider adding resource limits via systemd slice or container runtime"
+      fi
+    else
+      skipx "SC-39-cgroup-isolation" "SC-39: Cannot read cgroup for OpenClaw process (PID $SC39_OC_PID)"
+    fi
+    SC39_PID_NS=$(readlink "/proc/$SC39_OC_PID/ns/pid" 2>/dev/null)
+    SC39_HOST_PID_NS=$(readlink /proc/1/ns/pid 2>/dev/null)
+    if [[ -n "$SC39_PID_NS" && -n "$SC39_HOST_PID_NS" ]]; then
+      if [[ "$SC39_PID_NS" != "$SC39_HOST_PID_NS" ]]; then
+        passx "SC-39-pid-namespace" "SC-39: OpenClaw runs in a separate PID namespace — process isolation enforced"
+      else
+        warnx "SC-39-pid-namespace" "SC-39: OpenClaw shares the host PID namespace — processes are visible to and from the agent"
+      fi
+    fi
+    SC39_NET_NS=$(readlink "/proc/$SC39_OC_PID/ns/net" 2>/dev/null)
+    SC39_HOST_NET_NS=$(readlink /proc/1/ns/net 2>/dev/null)
+    if [[ -n "$SC39_NET_NS" && -n "$SC39_HOST_NET_NS" ]]; then
+      if [[ "$SC39_NET_NS" != "$SC39_HOST_NET_NS" ]]; then
+        passx "SC-39-net-namespace" "SC-39: OpenClaw runs in a separate network namespace — network isolation enforced"
+      else
+        warnx "SC-39-net-namespace" "SC-39: OpenClaw shares the host network namespace — agent can access all host network interfaces"
+      fi
+    fi
+  else
+    skipx "SC-39-cgroup-isolation" "SC-39: No running OpenClaw process found — cannot verify process isolation"
+  fi
+else
+  skipx "SC-39-cgroup-isolation" "SC-39: host-only mode — process isolation checks skipped"
+fi

--- a/assessment/checks/check-si.sh
+++ b/assessment/checks/check-si.sh
@@ -70,3 +70,38 @@ if [[ -f "$CHECKSUM_FILE" ]]; then
 else
   skipx "SI-7-checksum-mismatch" "SI-7: No CHECKSUMS.sha256 file found — generate with: sha256sum scripts/*.sh assessment/**/*.sh > CHECKSUMS.sha256"
 fi
+
+# SI-7: Software & Information Integrity — package signature verification
+log "SI-7: Package signature verification"
+if ! platform_supports apt_config_available; then
+  skipx "SI-7-package-signing" "SI-7: apt-config inspection is a Debian/Ubuntu construct; not applicable on ${SARGE_OS_DESCRIPTION} — review the platform's native package-signing policy separately"
+elif ! platform apt_config_available; then
+  skipx "SI-7-package-signing" "SI-7: apt-config not available — cannot verify package signature enforcement"
+else
+  ALLOW_UNAUTH=$(platform apt_allow_unauthenticated)
+  TRUSTED_KEYS=$(platform apt_trusted_keys_count)
+  if [[ "$ALLOW_UNAUTH" == "true" ]]; then
+    failx "SI-7-package-signing" "SI-7: APT::Get::AllowUnauthenticated is true — unsigned packages can be installed; unset it or set to false"
+  elif [[ -z "$TRUSTED_KEYS" || "$TRUSTED_KEYS" -eq 0 ]]; then
+    warnx "SI-7-package-signing" "SI-7: no apt trusted GPG keys found under /etc/apt/trusted.gpg.d/ — package signature verification may not be configured"
+  else
+    passx "SI-7-package-signing" "SI-7: apt signature verification enforced (AllowUnauthenticated=${ALLOW_UNAUTH:-unset}, $TRUSTED_KEYS trusted key file(s))"
+  fi
+fi
+
+# SI-16: Memory Protection — ASLR
+log "SI-16: Memory protection (ASLR)"
+if ! platform_supports aslr_setting; then
+  skipx "SI-16-aslr" "SI-16: /proc/sys/kernel/randomize_va_space is a Linux-specific control; review ${SARGE_OS_DESCRIPTION}'s native memory-protection posture separately"
+else
+  ASLR=$(platform aslr_setting)
+  if [[ -z "$ASLR" ]]; then
+    warnx "SI-16-aslr" "SI-16: could not read /proc/sys/kernel/randomize_va_space"
+  elif [[ "$ASLR" -eq 2 ]]; then
+    passx "SI-16-aslr" "SI-16: ASLR is fully enabled (randomize_va_space=2)"
+  elif [[ "$ASLR" -eq 1 ]]; then
+    warnx "SI-16-aslr" "SI-16: ASLR is only partially enabled (randomize_va_space=1) — set to 2 for full randomization"
+  else
+    failx "SI-16-aslr" "SI-16: ASLR is disabled (randomize_va_space=$ASLR) — enable it: sudo sysctl -w kernel.randomize_va_space=2"
+  fi
+fi

--- a/assessment/checks/check-sr.sh
+++ b/assessment/checks/check-sr.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check-sr.sh — Supply Chain Risk Management (SR) checks — NIST 800-53 Rev 5
+# Platform-specific data acquisition lives in lib/platforms/<os>.sh.
+
+# SR-11: Component Authenticity — skill source attribution
+#
+# Installed skills are third-party (or self-authored) components pulled
+# into the agent's tool surface. A skill with no source/author/origin
+# metadata is a supply-chain blind spot: there's no way to trace where
+# it came from or verify it wasn't tampered with. WARN (not FAIL) — this
+# is a review signal, not a hard block, mirroring how AS-7 treats missing
+# skill-workshop primitives.
+log "SR-11: Skill component authenticity"
+SR_SKILLS_DIR=""
+for candidate in "$HOME/.openclaw/skills" "$HOME/.claude/skills"; do
+  if [[ -d "$candidate" ]]; then
+    SR_SKILLS_DIR="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$SR_SKILLS_DIR" ]]; then
+  SKILL_COUNT=0
+  UNATTRIBUTED_COUNT=0
+  UNATTRIBUTED_NAMES=""
+  while IFS= read -r -d '' skill_md; do
+    SKILL_COUNT=$((SKILL_COUNT + 1))
+    if ! grep -qiE '"?(source|origin|author|publisher)"?[[:space:]]*[:=]' "$skill_md" 2>/dev/null; then
+      UNATTRIBUTED_COUNT=$((UNATTRIBUTED_COUNT + 1))
+      UNATTRIBUTED_NAMES="${UNATTRIBUTED_NAMES}${UNATTRIBUTED_NAMES:+, }$(basename "$(dirname "$skill_md")")"
+    fi
+  done < <(find "$SR_SKILLS_DIR" -maxdepth 2 -iname "SKILL.md" -print0 2>/dev/null)
+
+  if [[ "$SKILL_COUNT" -eq 0 ]]; then
+    skipx "SR-11-skill-attribution" "SR-11: no SKILL.md files found under $SR_SKILLS_DIR — nothing to verify"
+  elif [[ "$UNATTRIBUTED_COUNT" -eq 0 ]]; then
+    passx "SR-11-skill-attribution" "SR-11: all $SKILL_COUNT installed skill(s) under $SR_SKILLS_DIR declare source/author metadata"
+  else
+    warnx "SR-11-skill-attribution" "SR-11: $UNATTRIBUTED_COUNT of $SKILL_COUNT skill(s) under $SR_SKILLS_DIR have no source/author/origin metadata: $UNATTRIBUTED_NAMES"
+  fi
+else
+  skipx "SR-11-skill-attribution" "SR-11: no skills directory found (checked ~/.openclaw/skills, ~/.claude/skills)"
+fi
+
+# SR-11: Component Authenticity — package signing keys
+#
+# Reuses the same apt_trusted_keys_count probe SI-7 (check-si.sh) uses
+# for AllowUnauthenticated review — trusted GPG key material under
+# /etc/apt/trusted.gpg.d/ (and the legacy /etc/apt/trusted.gpg keyring)
+# is what lets apt verify package authenticity before install.
+log "SR-11: Package signing key material"
+if ! platform_supports apt_trusted_keys_count; then
+  skipx "SR-11-apt-signing-keys" "SR-11: apt trusted-key inspection is a Debian/Ubuntu construct; not applicable on ${SARGE_OS_DESCRIPTION} — review the platform's native package-signing policy separately"
+else
+  TRUSTED_KEYS=$(platform apt_trusted_keys_count)
+  if [[ -z "$TRUSTED_KEYS" || "$TRUSTED_KEYS" -eq 0 ]]; then
+    warnx "SR-11-apt-signing-keys" "SR-11: no APT trusted GPG keys found under /etc/apt/trusted.gpg.d/ — package authenticity cannot be verified"
+  else
+    passx "SR-11-apt-signing-keys" "SR-11: $TRUSTED_KEYS APT trusted GPG key file(s) present — package authenticity verification is active"
+  fi
+fi

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -1069,5 +1069,33 @@
     "expected": "Agent runs in a separate network namespace or has firewall-restricted access",
     "why": "Sharing the host network namespace gives the agent access to all host network interfaces, including internal/management networks. Network namespace isolation limits the agent's network surface.",
     "fix": "Run OpenClaw in a container with a dedicated network namespace, or use iptables/nftables to restrict the agent user's network access."
+  },
+  "RA-5-scanner-installed": {
+    "family": "RA-5 \u2014 Vulnerability Monitoring and Scanning",
+    "what": "No vulnerability scanner installed on the host",
+    "expected": "At least one scanner available (trivy, grype, oscap, lynis, or debsecan)",
+    "why": "NIST 800-53 RA-5 requires automated vulnerability scanning. Without a scanner, vulnerabilities in system packages and configurations go undetected until exploited.",
+    "fix": "Install trivy (recommended for container/OS scanning): curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh"
+  },
+  "RA-5-scan-evidence": {
+    "family": "RA-5 \u2014 Vulnerability Monitoring and Scanning",
+    "what": "No recent vulnerability scan results found (within 30 days)",
+    "expected": "Recent scan output in ~/.openclaw/scans/, /var/log/trivy/, or equivalent",
+    "why": "RA-5 requires scanning at an organization-defined frequency. A 30-day window without evidence suggests scanning has lapsed or results are not being retained.",
+    "fix": "Run a vulnerability scan and store results: trivy fs --scanners vuln / --output ~/.openclaw/scans/$(date +%Y%m%d).json --format json"
+  },
+  "RA-5-npm-audit": {
+    "family": "RA-5 \u2014 Vulnerability Monitoring and Scanning",
+    "what": "Known vulnerabilities found in OpenClaw npm dependencies",
+    "expected": "Zero critical/high vulnerabilities in npm audit",
+    "why": "OpenClaw's Node.js dependencies are part of the agent's attack surface. Known vulnerabilities in these packages can be exploited by malicious inputs or compromised upstream packages.",
+    "fix": "cd /usr/lib/node_modules/openclaw && npm audit fix"
+  },
+  "RA-5-os-security-patches": {
+    "family": "RA-5 \u2014 Vulnerability Monitoring and Scanning",
+    "what": "OS security patches are pending",
+    "expected": "All available security patches applied",
+    "why": "Pending security patches represent known vulnerabilities with available fixes. Delaying application increases the window of exposure.",
+    "fix": "sudo apt update && sudo apt upgrade -y"
   }
 }

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -1,49 +1,49 @@
 {
   "_doc": {
     "purpose": "Per-finding rationale catalog for sarge reports. report.sh joins this with assessment results by check_id to render the Findings section.",
-    "naming_convention": "<NIST-FAMILY>-<CONTROL-NUMBER>-<short-slug>. Family + control are uppercase (e.g. AC-3); slug is lowercase-kebab. Examples: AC-3-secrets-perm, CM-7-cups-running, IA-5-pwquality-minlen. IDs are stable — once published do not rename without a migration note.",
+    "naming_convention": "<NIST-FAMILY>-<CONTROL-NUMBER>-<short-slug>. Family + control are uppercase (e.g. AC-3); slug is lowercase-kebab. Examples: AC-3-secrets-perm, CM-7-cups-running, IA-5-pwquality-minlen. IDs are stable \u2014 once published do not rename without a migration note.",
     "schema": {
-      "family": "Long name of the NIST 800-53 Rev 5 family + control (e.g. 'AC-3 — Access Enforcement').",
-      "what": "Short description of the observed condition. Templates may include shell-style placeholders like {value} that report.sh leaves as-is — the finding 'description' from the check script is what actually appears in reports; this 'what' is reference-only.",
+      "family": "Long name of the NIST 800-53 Rev 5 family + control (e.g. 'AC-3 \u2014 Access Enforcement').",
+      "what": "Short description of the observed condition. Templates may include shell-style placeholders like {value} that report.sh leaves as-is \u2014 the finding 'description' from the check script is what actually appears in reports; this 'what' is reference-only.",
       "expected": "What the value/state should be. May be a string or a per-platform map (same shape as 'fix').",
       "why": "2-3 sentences explaining the security risk. References the NIST 800-53 Rev 5 control by name. May be a string or a per-platform map (same shape as 'fix').",
       "fix": "Runnable command or one-line action. May be a string or a per-platform map: {\"default\": \"...\", \"macos\": \"...\", \"ubuntu\": \"...\"}. report.sh resolves via $SARGE_OS with fallback to 'default'.",
-      "scope": "\"host\" (default) or \"agent\" — agent-scoped findings probe the OpenClaw / agent-runtime overlay and are excluded in --host-only mode."
+      "scope": "\"host\" (default) or \"agent\" \u2014 agent-scoped findings probe the OpenClaw / agent-runtime overlay and are excluded in --host-only mode."
     },
     "coverage": "Every fail \"...\" and warn \"...\" callsite in assessment/checks/check-*.sh. PASS/SKIP do not need entries."
   },
   "AC-2-empty-password": {
-    "family": "AC-2 — Account Management",
+    "family": "AC-2 \u2014 Account Management",
     "what": "Local account(s) found with empty password fields in /etc/shadow",
     "expected": "All accounts have a password set or are locked",
     "why": "An empty password field allows login with no authentication, defeating identity assurance entirely. NIST 800-53 AC-2 requires the organization to manage account credentials and disable inactive or improperly provisioned accounts. Empty-password accounts are usually leftover service accounts or misconfigured users that an attacker can pivot through trivially.",
     "fix": "sudo passwd -l <username>  # lock the account, or set a password with: sudo passwd <username>"
   },
   "AC-2-uid-zero": {
-    "family": "AC-2 — Account Management",
+    "family": "AC-2 \u2014 Account Management",
     "what": "Non-root account(s) found with UID 0 in /etc/passwd",
     "expected": "Only the 'root' account has UID 0",
-    "why": "UID 0 is the kernel's superuser — any account assigned UID 0 is root, regardless of name. NIST 800-53 AC-2 requires authoritative account inventory; shadow root accounts bypass auditing because logs key off the username while privileges key off the UID. Attackers create such accounts to persist through password rotations on the canonical root.",
+    "why": "UID 0 is the kernel's superuser \u2014 any account assigned UID 0 is root, regardless of name. NIST 800-53 AC-2 requires authoritative account inventory; shadow root accounts bypass auditing because logs key off the username while privileges key off the UID. Attackers create such accounts to persist through password rotations on the canonical root.",
     "fix": "sudo usermod -u <new-uid> <username>  # assign a non-zero UID, or remove the account: sudo userdel <username>"
   },
   "AC-3-openclaw-dir-perm": {
-    "family": "AC-3 — Access Enforcement",
+    "family": "AC-3 \u2014 Access Enforcement",
     "what": "~/.openclaw directory permissions are not 700",
     "expected": "700 (owner-only)",
-    "why": "The ~/.openclaw directory holds workspace state, agent memory, and credential paths used by OpenClaw subprocesses. NIST 800-53 AC-3 requires enforcement of approved access — group/world-readable workspace directories let other local users enumerate which agents and accounts the operator runs. Even read access leaks operational intent.",
+    "why": "The ~/.openclaw directory holds workspace state, agent memory, and credential paths used by OpenClaw subprocesses. NIST 800-53 AC-3 requires enforcement of approved access \u2014 group/world-readable workspace directories let other local users enumerate which agents and accounts the operator runs. Even read access leaks operational intent.",
     "fix": "chmod 700 ~/.openclaw",
     "scope": "agent"
   },
   "AC-3-secrets-dir-perm": {
-    "family": "AC-3 — Access Enforcement",
+    "family": "AC-3 \u2014 Access Enforcement",
     "what": "~/.openclaw/secrets directory permissions are not 700",
     "expected": "700 (owner-only)",
-    "why": "Group/world-readable secrets directory exposes OAuth tokens and API keys cached by OpenClaw to other local users or processes. NIST 800-53 AC-3 requires access enforcement that limits sensitive resources to authorized identities. Any unprivileged local process — including a compromised browser or editor — can read tokens and impersonate the operator against external services.",
+    "why": "Group/world-readable secrets directory exposes OAuth tokens and API keys cached by OpenClaw to other local users or processes. NIST 800-53 AC-3 requires access enforcement that limits sensitive resources to authorized identities. Any unprivileged local process \u2014 including a compromised browser or editor \u2014 can read tokens and impersonate the operator against external services.",
     "fix": "chmod 700 ~/.openclaw/secrets",
     "scope": "agent"
   },
   "AC-3-secret-file-perm": {
-    "family": "AC-3 — Access Enforcement",
+    "family": "AC-3 \u2014 Access Enforcement",
     "what": "Individual secret file under ~/.openclaw/secrets is not 600",
     "expected": "600 (owner read/write only)",
     "why": "Even if the parent directory is locked down, lax file modes on individual tokens allow exfiltration via backup, sync, or container bind-mount. NIST 800-53 AC-3 requires per-resource access enforcement, not just directory-level. A 644 token survives a tarball or rsync that preserves modes but loses parent-dir context.",
@@ -51,160 +51,160 @@
     "scope": "agent"
   },
   "AC-6-passwordless-sudo": {
-    "family": "AC-6 — Least Privilege",
+    "family": "AC-6 \u2014 Least Privilege",
     "what": "Current user has passwordless sudo (NOPASSWD) enabled",
     "expected": "sudo requires a password (no NOPASSWD for this user)",
-    "why": "Passwordless sudo turns any code execution as the user — a malicious script, a hijacked editor plugin, a curl|bash mistake — into immediate root. NIST 800-53 AC-6 requires least privilege, including the principle that elevation must require an explicit re-authentication. Cron and CI runners sometimes need NOPASSWD for narrow commands; an interactive operator account should not.",
+    "why": "Passwordless sudo turns any code execution as the user \u2014 a malicious script, a hijacked editor plugin, a curl|bash mistake \u2014 into immediate root. NIST 800-53 AC-6 requires least privilege, including the principle that elevation must require an explicit re-authentication. Cron and CI runners sometimes need NOPASSWD for narrow commands; an interactive operator account should not.",
     "fix": "Edit /etc/sudoers.d/ entries with 'sudo visudo' and remove NOPASSWD: from the operator user, or scope it to specific commands."
   },
   "AC-6-user-in-sudo-group": {
-    "family": "AC-6 — Least Privilege",
+    "family": "AC-6 \u2014 Least Privilege",
     "what": "Current user is a member of the 'sudo' group",
     "expected": "Service/operator accounts that don't need elevation should not be in 'sudo'",
     "why": "Membership in 'sudo' confers blanket root capability subject only to password challenge. NIST 800-53 AC-6 calls for separation of duties between operational and administrative accounts. If this account runs OpenClaw, agents, or daemons day-to-day, a compromise of the agent shell becomes a compromise of root.",
     "fix": "If a separate admin account exists: sudo deluser <username> sudo  # otherwise create a dedicated admin account first"
   },
   "AC-17-ufw-inactive": {
-    "family": "AC-17 — Remote Access",
+    "family": "AC-17 \u2014 Remote Access",
     "what": "Host firewall is not active",
     "expected": {
       "default": "UFW reports 'Status: active'",
       "macos": "Application Firewall reports globalstate = 1"
     },
-    "why": "Without an active host firewall, any service that binds to an external interface is reachable from the network. NIST 800-53 AC-17 requires controls on remote access paths. An inactive firewall means the host depends entirely on perimeter or upstream protection — fine in some deployments, but invisible drift if you assumed the firewall was enforcing.",
+    "why": "Without an active host firewall, any service that binds to an external interface is reachable from the network. NIST 800-53 AC-17 requires controls on remote access paths. An inactive firewall means the host depends entirely on perimeter or upstream protection \u2014 fine in some deployments, but invisible drift if you assumed the firewall was enforcing.",
     "fix": {
       "default": "sudo ufw enable  # review rules first with: sudo ufw status verbose",
       "macos": "sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
     }
   },
   "AC-17-ufw-not-installed": {
-    "family": "AC-17 — Remote Access",
+    "family": "AC-17 \u2014 Remote Access",
     "what": "No recognized host firewall is installed",
     "expected": {
       "default": "UFW or another host firewall (nftables, firewalld) is in place",
       "macos": "Application Firewall is available (built-in on macOS)"
     },
-    "why": "Without a recognized host firewall, host-level network access enforcement is unverified. NIST 800-53 AC-17 requires documented controls on remote access. If you use an alternative firewall or rely on a cloud security group, that's fine — but Sarge cannot confirm it, so this is flagged as a gap until you enable the firewall or document the alternative.",
+    "why": "Without a recognized host firewall, host-level network access enforcement is unverified. NIST 800-53 AC-17 requires documented controls on remote access. If you use an alternative firewall or rely on a cloud security group, that's fine \u2014 but Sarge cannot confirm it, so this is flagged as a gap until you enable the firewall or document the alternative.",
     "fix": {
       "default": "sudo apt install ufw && sudo ufw enable  # or document the alternative firewall in baseline/",
       "macos": "sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
     }
   },
   "AC-17-external-ports": {
-    "family": "AC-17 — Remote Access",
+    "family": "AC-17 \u2014 Remote Access",
     "what": "Externally-listening TCP ports detected (not bound to loopback)",
     "expected": "Only intentionally-exposed services listen on non-loopback addresses",
-    "why": "Every externally-bound port is an attack surface. NIST 800-53 AC-17 requires that remote access points be authorized, monitored, and protected. Many drift incidents start with a service the operator forgot was exposed — a debug port, a leftover dev container, a default-config Postgres.",
+    "why": "Every externally-bound port is an attack surface. NIST 800-53 AC-17 requires that remote access points be authorized, monitored, and protected. Many drift incidents start with a service the operator forgot was exposed \u2014 a debug port, a leftover dev container, a default-config Postgres.",
     "fix": "Review the listed ports with 'ss -tlnp' and either bind to 127.0.0.1, firewall the port, or document it as an intended remote service."
   },
   "AU-2-auditd-not-running": {
-    "family": "AU-2 — Audit Events",
+    "family": "AU-2 \u2014 Audit Events",
     "what": "Audit daemon is not running",
     "expected": "Audit daemon is active and persisting events",
     "why": "Without the audit daemon, security-relevant kernel and file events aren't recorded, so post-incident forensics rely entirely on application logs and the system journal (which can be tampered with by root). NIST 800-53 AU-2 requires the system to generate audit records for defined events; the audit daemon is the standard Linux mechanism. No audit daemon = no defensible timeline.",
     "fix": "sudo apt install auditd && sudo systemctl enable --now auditd"
   },
   "AU-2-journald-inactive": {
-    "family": "AU-2 — Audit Events",
+    "family": "AU-2 \u2014 Audit Events",
     "what": "systemd-journald is not active",
     "expected": "systemd-journald running, or syslog explicitly configured as substitute",
     "why": "journald collects logs from systemd units and the kernel; without it (or syslog), service logs are lost between restarts. NIST 800-53 AU-2 requires consistent audit event capture. A host with no journald and no syslog has no audit trail for daemon failures or security warnings.",
     "fix": "sudo systemctl enable --now systemd-journald  # or verify rsyslog/syslog-ng is configured"
   },
   "AU-2-journal-not-persisted": {
-    "family": "AU-2 — Audit Events",
+    "family": "AU-2 \u2014 Audit Events",
     "what": "journald appears to not be persisting logs to disk",
     "expected": "Storage=persistent in /etc/systemd/journald.conf",
     "why": "When journald runs in volatile (RAM-only) mode, all logs vanish on reboot. NIST 800-53 AU-2 expects audit records to survive long enough to support incident response. A reboot during an attack erases the evidence.",
     "fix": "sudo sed -i 's/^#\\?Storage=.*/Storage=persistent/' /etc/systemd/journald.conf && sudo systemctl restart systemd-journald"
   },
   "AU-9-audit-log-bad-owner": {
-    "family": "AU-9 — Protection of Audit Information",
+    "family": "AU-9 \u2014 Protection of Audit Information",
     "what": "/var/log/audit/audit.log is not owned by root",
     "expected": "Owner is root",
     "why": "Audit logs owned by a non-root user can be tampered with by that user, defeating non-repudiation. NIST 800-53 AU-9 requires audit information to be protected from unauthorized modification. If the log owner can write to it, the audit trail can be edited to hide actions.",
     "fix": "sudo chown root:root /var/log/audit/audit.log"
   },
   "AU-9-audit-log-perm": {
-    "family": "AU-9 — Protection of Audit Information",
+    "family": "AU-9 \u2014 Protection of Audit Information",
     "what": "/var/log/audit/audit.log permissions are not 600",
     "expected": "600",
     "why": "World/group-readable audit logs leak sensitive event metadata (commands run, files accessed, user activity) to any local account. NIST 800-53 AU-9 requires that audit information be protected from unauthorized read as well as write. This is also a covert-channel risk: a low-privilege process can fingerprint admin behaviour.",
     "fix": "sudo chmod 600 /var/log/audit/audit.log"
   },
   "AU-9-audit-log-missing": {
-    "family": "AU-9 — Protection of Audit Information",
+    "family": "AU-9 \u2014 Protection of Audit Information",
     "what": "Audit daemon is running but /var/log/audit/audit.log does not exist",
     "expected": "Audit log present at the configured location",
-    "why": "The audit daemon is running but no log file exists at the standard path — likely a misconfiguration in the audit daemon config, or audit events being routed elsewhere. NIST 800-53 AU-9 cannot be enforced if the audit sink is unknown. This is a silent-failure mode where operators believe they have audit coverage but don't.",
+    "why": "The audit daemon is running but no log file exists at the standard path \u2014 likely a misconfiguration in the audit daemon config, or audit events being routed elsewhere. NIST 800-53 AU-9 cannot be enforced if the audit sink is unknown. This is a silent-failure mode where operators believe they have audit coverage but don't.",
     "fix": "Check 'log_file' in /etc/audit/auditd.conf and review with: sudo aureport -t"
   },
   "AU-12-no-openclaw-rules": {
-    "family": "AU-12 — Audit Generation",
+    "family": "AU-12 \u2014 Audit Generation",
     "what": "No audit rules cover ~/.openclaw/secrets",
     "expected": "auditctl -l shows watch rules for the secrets directory",
-    "why": "Without watch rules, reads/writes to high-value secret material are not recorded. NIST 800-53 AU-12 requires that audit records be generated for defined auditable events — for sarge's threat model, OpenClaw secret access is one of those events. Detecting credential exfiltration after the fact requires this trail.",
+    "why": "Without watch rules, reads/writes to high-value secret material are not recorded. NIST 800-53 AU-12 requires that audit records be generated for defined auditable events \u2014 for sarge's threat model, OpenClaw secret access is one of those events. Detecting credential exfiltration after the fact requires this trail.",
     "fix": "Run: scripts/harden-auditd.sh  # or add: sudo auditctl -w ~/.openclaw/secrets -p rwxa -k openclaw-secrets",
     "scope": "agent"
   },
   "AU-12-no-auth-rules": {
-    "family": "AU-12 — Audit Generation",
+    "family": "AU-12 \u2014 Audit Generation",
     "what": "No audit rules cover /etc/passwd, /etc/shadow, or /etc/sudoers",
     "expected": "Watch rules on the auth-critical files",
     "why": "These files define who can log in and who can elevate. NIST 800-53 AU-12 expects audit generation for changes to authentication and authorization data. Unmonitored writes to /etc/sudoers are a classic persistence vector.",
     "fix": "sudo auditctl -w /etc/passwd -p wa -k identity && sudo auditctl -w /etc/shadow -p wa -k identity && sudo auditctl -w /etc/sudoers -p wa -k identity"
   },
   "CM-2-no-baseline": {
-    "family": "CM-2 — Baseline Configuration",
+    "family": "CM-2 \u2014 Baseline Configuration",
     "what": "Sarge baseline file (baseline/openclaw.json.baseline) not found",
     "expected": "Baseline file present in repo to anchor drift detection",
     "why": "Without a documented baseline, every change looks new and there's no anchor for what 'good' looks like. NIST 800-53 CM-2 requires maintaining a current baseline configuration of the information system. For sarge specifically, the baseline file is what subsequent runs compare against to detect drift in the OpenClaw layout.",
     "fix": "Restore baseline/openclaw.json.baseline from the sarge repo, or regenerate from a known-good host."
   },
   "CM-6-unattended-not-installed": {
-    "family": "CM-6 — Configuration Settings",
+    "family": "CM-6 \u2014 Configuration Settings",
     "what": "unattended-upgrades package is not installed",
     "expected": "unattended-upgrades installed and configured for security updates",
     "why": "Without unattended-upgrades, security patches require manual intervention and tend to lag. NIST 800-53 CM-6 (and SI-2 / Flaw Remediation) require timely application of vendor-released fixes. Background auto-patching narrows the window between disclosure and exploitation.",
     "fix": "sudo apt install unattended-upgrades && sudo dpkg-reconfigure -plow unattended-upgrades"
   },
   "CM-6-unattended-not-configured": {
-    "family": "CM-6 — Configuration Settings",
+    "family": "CM-6 \u2014 Configuration Settings",
     "what": "unattended-upgrades is installed but the auto-reboot setting in 50unattended-upgrades is not configured",
     "expected": "Unattended-Upgrade::Automatic-Reboot directive present",
-    "why": "Installed-but-unconfigured leaves you believing patches are applied when in fact the policy file is incomplete. NIST 800-53 CM-6 requires documented and enforced configuration. Verify the file contents match your maintenance window — kernel updates without auto-reboot still leave the host on the old vulnerable kernel.",
+    "why": "Installed-but-unconfigured leaves you believing patches are applied when in fact the policy file is incomplete. NIST 800-53 CM-6 requires documented and enforced configuration. Verify the file contents match your maintenance window \u2014 kernel updates without auto-reboot still leave the host on the old vulnerable kernel.",
     "fix": "Edit /etc/apt/apt.conf.d/50unattended-upgrades and confirm Automatic-Reboot, Allowed-Origins, and email settings match policy."
   },
   "CM-6-pending-updates-low": {
-    "family": "CM-6 — Configuration Settings",
+    "family": "CM-6 \u2014 Configuration Settings",
     "what": "Small number of package updates pending (1-5)",
     "expected": "Apply pending updates within the maintenance window",
     "why": "A small backlog is normal but should not be allowed to grow. NIST 800-53 CM-6 / SI-2 require tracking and applying configuration and security updates. Catching this at single-digit count keeps the apply-and-test cycle cheap.",
     "fix": "sudo apt update && sudo apt upgrade  # review first with: apt list --upgradable"
   },
   "CM-6-pending-updates-high": {
-    "family": "CM-6 — Configuration Settings",
+    "family": "CM-6 \u2014 Configuration Settings",
     "what": "More than 5 package updates pending",
     "expected": "Apply security updates immediately",
     "why": "A large patch backlog usually means the host has missed at least one security advisory cycle. NIST 800-53 CM-6 / SI-2 require timely flaw remediation. Each unpatched package multiplies the chance that a published CVE is exploitable on this host.",
     "fix": "sudo apt update && sudo apt upgrade  # for security-only: sudo unattended-upgrade -d"
   },
   "CM-7-risky-service-running": {
-    "family": "CM-7 — Least Functionality",
+    "family": "CM-7 \u2014 Least Functionality",
     "what": "A service from the deny-list is currently running (telnet, rsh, rlogin, vsftpd, pure-ftpd, proftpd, xinetd, cups, avahi-daemon)",
     "expected": "Service stopped and disabled if not explicitly required",
     "why": "These services are commonly enabled by default but rarely needed on a server, and several (telnet, rsh, rlogin, plain FTP) transmit credentials in clear. NIST 800-53 CM-7 requires the system be configured to provide only essential capabilities. Each unused listener is an attack surface for no functional gain.",
     "fix": "sudo systemctl disable --now <service>  # confirm with whoever owns the host first"
   },
   "CM-7-risky-service-enabled": {
-    "family": "CM-7 — Least Functionality",
+    "family": "CM-7 \u2014 Least Functionality",
     "what": "A risky service is enabled (will start at boot) even though not currently running",
     "expected": "Service disabled if not explicitly required",
-    "why": "An enabled-but-stopped service is one reboot or one operator mistake away from active. NIST 800-53 CM-7 requires removing or disabling unused capabilities — leaving them enabled defers the risk rather than removing it. This is a common 'I'll fix it later' state that quietly persists.",
+    "why": "An enabled-but-stopped service is one reboot or one operator mistake away from active. NIST 800-53 CM-7 requires removing or disabling unused capabilities \u2014 leaving them enabled defers the risk rather than removing it. This is a common 'I'll fix it later' state that quietly persists.",
     "fix": "sudo systemctl disable <service>  # and consider: sudo apt purge <package>"
   },
   "CM-7-ssh-permit-root": {
-    "family": "CM-7 — Least Functionality",
+    "family": "CM-7 \u2014 Least Functionality",
     "what": "SSH PermitRootLogin is not 'no' or 'prohibit-password'",
     "expected": "PermitRootLogin no  (or prohibit-password if key-only root is required)",
     "why": "Direct root SSH login means a single compromised credential or key is full system takeover, with no audit trail tying actions to a human operator. NIST 800-53 CM-7 (least functionality) and AC-6 (least privilege) both argue for forcing operators to log in as themselves and elevate via sudo. This also breaks brute-force attempts since 'root' is the universal target username.",
@@ -214,7 +214,7 @@
     }
   },
   "CM-7-ssh-password-auth": {
-    "family": "CM-7 — Least Functionality",
+    "family": "CM-7 \u2014 Least Functionality",
     "what": "SSH PasswordAuthentication is not explicitly disabled",
     "expected": "PasswordAuthentication no  (key-based auth only)",
     "why": "Password-based SSH is vulnerable to brute force and credential stuffing in a way key-based auth is not. NIST 800-53 CM-7 plus IA-2 (identification & authentication) favor cryptographic authenticators over reusable passwords for remote access. Once you've migrated all operators to keys, this should be locked down.",
@@ -224,84 +224,84 @@
     }
   },
   "IA-5-pass-max-days": {
-    "family": "IA-5 — Authenticator Management",
+    "family": "IA-5 \u2014 Authenticator Management",
     "what": "PASS_MAX_DAYS in /etc/login.defs is unset or greater than 90",
     "expected": "PASS_MAX_DAYS <= 90",
     "why": "Without password-age caps, compromised credentials remain valid indefinitely. NIST 800-53 IA-5 requires periodic authenticator refresh. While modern guidance debates rotation frequency for human users, server policy still typically enforces a ceiling so that abandoned accounts can't accumulate stale, breached credentials.",
     "fix": "sudo sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS\\t90/' /etc/login.defs"
   },
   "IA-5-pass-min-days": {
-    "family": "IA-5 — Authenticator Management",
+    "family": "IA-5 \u2014 Authenticator Management",
     "what": "PASS_MIN_DAYS in /etc/login.defs is unset or 0",
     "expected": "PASS_MIN_DAYS >= 1",
     "why": "PASS_MIN_DAYS=0 lets a user immediately rotate back to a previous password, defeating any history-based reuse policy. NIST 800-53 IA-5 expects password change controls to actually take effect. A non-zero minimum prevents the trivial 'change-then-change-back' bypass.",
     "fix": "sudo sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS\\t1/' /etc/login.defs"
   },
   "IA-5-pass-warn-age": {
-    "family": "IA-5 — Authenticator Management",
+    "family": "IA-5 \u2014 Authenticator Management",
     "what": "PASS_WARN_AGE in /etc/login.defs is unset or below 7",
     "expected": "PASS_WARN_AGE >= 7",
     "why": "Without an expiry warning window, users are surprised by lockout and tend to pick low-effort replacement passwords under time pressure. NIST 800-53 IA-5 supports operationally workable authenticator management. A week of warning lets users plan a real password rotation.",
     "fix": "sudo sed -i 's/^PASS_WARN_AGE.*/PASS_WARN_AGE\\t7/' /etc/login.defs"
   },
   "IA-5-pwquality-minlen": {
-    "family": "IA-5 — Authenticator Management",
+    "family": "IA-5 \u2014 Authenticator Management",
     "what": "pwquality minlen is unset or below 12",
     "expected": "minlen >= 12",
     "why": "Short passwords are within reach of offline cracking against any leaked hash. NIST 800-53 IA-5 requires authenticators of sufficient strength for the protected resource. 12 characters is the contemporary floor for password complexity guidance against modern GPU-assisted cracking.",
     "fix": "Edit /etc/security/pwquality.conf and set: minlen = 12"
   },
   "IA-5-pwquality-credit": {
-    "family": "IA-5 — Authenticator Management",
+    "family": "IA-5 \u2014 Authenticator Management",
     "what": "pwquality character-class credits (dcredit/ucredit/ocredit/lcredit) not set",
     "expected": "Credits configured to require character-class diversity",
-    "why": "Without character-class credits, pwquality only enforces length — users may pick all-lowercase strings. NIST 800-53 IA-5 calls for authenticator complexity appropriate to the threat. Class credits force at least some diversity even when minlen alone would pass.",
+    "why": "Without character-class credits, pwquality only enforces length \u2014 users may pick all-lowercase strings. NIST 800-53 IA-5 calls for authenticator complexity appropriate to the threat. Class credits force at least some diversity even when minlen alone would pass.",
     "fix": "Edit /etc/security/pwquality.conf and add: dcredit = -1, ucredit = -1, ocredit = -1, lcredit = -1"
   },
   "IA-5-pwquality-missing": {
-    "family": "IA-5 — Authenticator Management",
+    "family": "IA-5 \u2014 Authenticator Management",
     "what": "/etc/security/pwquality.conf does not exist",
     "expected": "libpam-pwquality installed and configured",
     "why": "No pwquality means no enforced complexity, length, or dictionary checks at password-set time. NIST 800-53 IA-5 requires authenticator strength enforcement at the point of creation, not just at the point of use. Without pwquality, weak passwords get accepted and only get caught later (if ever) by a breach.",
     "fix": "sudo apt install libpam-pwquality  # then configure /etc/security/pwquality.conf"
   },
   "IA-2-faillock-not-configured": {
-    "family": "IA-2 — Identification and Authentication",
+    "family": "IA-2 \u2014 Identification and Authentication",
     "what": "pam_faillock is not configured in /etc/pam.d/common-auth",
     "expected": "pam_faillock entries present in PAM auth stack",
     "why": "Without account-lockout, brute-force attempts can run unbounded against console and SSH password logins. NIST 800-53 IA-2 expects the system to limit consecutive invalid login attempts. faillock is the standard Linux mechanism; without it, defense relies entirely on fail2ban or upstream rate limiting.",
     "fix": "sudo pam-auth-update --enable faillock  # then review /etc/security/faillock.conf"
   },
   "IA-2-faillock-deny": {
-    "family": "IA-2 — Identification and Authentication",
+    "family": "IA-2 \u2014 Identification and Authentication",
     "what": "faillock deny threshold is unset or above 5",
     "expected": "deny <= 5 attempts",
     "why": "A high deny threshold allows many guesses before lockout, undermining the brute-force protection. NIST 800-53 IA-2 expects login-attempt limits sized to deter automated guessing. Five is a common balance between operator typos and attacker scripts.",
     "fix": "Edit /etc/security/faillock.conf and set: deny = 5"
   },
   "IA-2-faillock-unlock-time": {
-    "family": "IA-2 — Identification and Authentication",
+    "family": "IA-2 \u2014 Identification and Authentication",
     "what": "faillock unlock_time is unset or below 1800 seconds",
     "expected": "unlock_time >= 1800 (30 min)",
     "why": "Short unlock windows let an attacker resume guessing minutes later, drastically extending the effective attempt budget. NIST 800-53 IA-2 expects lockout durations long enough to actually slow brute force. 30 minutes per lock keeps attacker throughput negligible while remaining recoverable for legitimate operator typos.",
     "fix": "Edit /etc/security/faillock.conf and set: unlock_time = 1800"
   },
   "IA-2-faillock-conf-missing": {
-    "family": "IA-2 — Identification and Authentication",
+    "family": "IA-2 \u2014 Identification and Authentication",
     "what": "pam_faillock referenced in PAM stack but /etc/security/faillock.conf is missing",
     "expected": "faillock.conf present with documented thresholds",
-    "why": "Without the conf file, faillock falls back to compiled defaults — defaults that vary across distributions and are hard to audit. NIST 800-53 IA-2 expects authenticator behavior to be documented and enforced. Drop the conf in place to make policy explicit.",
+    "why": "Without the conf file, faillock falls back to compiled defaults \u2014 defaults that vary across distributions and are hard to audit. NIST 800-53 IA-2 expects authenticator behavior to be documented and enforced. Drop the conf in place to make policy explicit.",
     "fix": "sudo cp /usr/share/doc/libpam-modules/examples/faillock.conf /etc/security/faillock.conf  # or create from scratch with deny= and unlock_time= entries"
   },
   "IA-2-tmout-unset": {
-    "family": "IA-2 — Identification and Authentication",
+    "family": "IA-2 \u2014 Identification and Authentication",
     "what": "TMOUT shell timeout not configured in /etc/profile or /etc/profile.d/",
     "expected": "TMOUT set (recommend 900 seconds)",
-    "why": "Idle interactive sessions left logged in are a session-hijacking risk if the operator walks away. NIST 800-53 IA-2 (specifically IA-2(8) — session lock) calls for terminating or locking sessions after a defined inactivity period. TMOUT is the bash-level mechanism; it complements display-locker policies for unattended terminals.",
+    "why": "Idle interactive sessions left logged in are a session-hijacking risk if the operator walks away. NIST 800-53 IA-2 (specifically IA-2(8) \u2014 session lock) calls for terminating or locking sessions after a defined inactivity period. TMOUT is the bash-level mechanism; it complements display-locker policies for unattended terminals.",
     "fix": "echo 'TMOUT=900' | sudo tee /etc/profile.d/tmout.sh && sudo chmod 644 /etc/profile.d/tmout.sh"
   },
   "SC-8-cloudflared-not-detected": {
-    "family": "SC-8 — Transmission Confidentiality",
+    "family": "SC-8 \u2014 Transmission Confidentiality",
     "what": "OpenClaw gateway is listening but cloudflared is not running",
     "expected": "cloudflared running (Cloudflare Tunnel TLS termination) or TLS configured directly on the gateway",
     "why": "Without TLS termination, gateway traffic is unencrypted on the wire, exposing tokens and agent payloads. NIST 800-53 SC-8 requires confidentiality of transmitted information. The OpenClaw deployment pattern relies on Cloudflare Tunnel for TLS; if cloudflared isn't running, either the tunnel is down or the gateway is exposed without TLS.",
@@ -309,7 +309,7 @@
     "scope": "agent"
   },
   "SC-28-config-perm": {
-    "family": "SC-28 — Protection of Information at Rest",
+    "family": "SC-28 \u2014 Protection of Information at Rest",
     "what": "OpenClaw runtime config (~/.openclaw/openclaw.json, or legacy ~/.openclaw/config.json) permissions are not 600 or 400",
     "expected": "600 (or 400 if read-only is sufficient)",
     "why": "The OpenClaw config file holds connection details and inline credentials for the runtime (provider tokens, MCP creds, delivery secrets). NIST 800-53 SC-28 requires protection of information at rest. World/group-readable config gives any local process a roadmap of services and their auth material.",
@@ -317,7 +317,7 @@
     "scope": "agent"
   },
   "SC-28-config-owner": {
-    "family": "SC-28 — Protection of Information at Rest",
+    "family": "SC-28 \u2014 Protection of Information at Rest",
     "what": "OpenClaw runtime config (~/.openclaw/openclaw.json, or legacy ~/.openclaw/config.json) is owned by an unexpected user",
     "expected": "Owned by the current operator/service user",
     "why": "Wrong ownership often means the file was created by a different account (root via sudo, an installer, or a previous user) and may have unexpected permission semantics. NIST 800-53 SC-28 + AC-3 require explicit ownership of sensitive resources. Sort out who is supposed to own the config and align permissions.",
@@ -325,7 +325,7 @@
     "scope": "agent"
   },
   "SC-28-world-readable-secrets": {
-    "family": "SC-28 — Protection of Information at Rest",
+    "family": "SC-28 \u2014 Protection of Information at Rest",
     "what": "World-readable sensitive files found inside ~/.openclaw (config, secrets/, credentials/, auth/, or credential-shaped filenames)",
     "expected": "No files matching Sarge's known-sensitive allowlist under ~/.openclaw are world-readable (mode bit o+r unset)",
     "why": "World-readable credential material in the OpenClaw workspace exposes provider tokens, MCP credentials, and cached auth to any local user. NIST 800-53 SC-28 requires confidentiality at rest. The check is scoped to known-sensitive paths so intentionally-readable workspace canon (SOUL.md, USER.md, AGENTS.md, etc.) does not create false positives that would drown the real signal.",
@@ -333,52 +333,52 @@
     "scope": "agent"
   },
   "SI-2-security-updates-low": {
-    "family": "SI-2 — Flaw Remediation",
+    "family": "SI-2 \u2014 Flaw Remediation",
     "what": "1-3 security updates pending",
     "expected": "Apply security updates within the maintenance window",
     "why": "Even a small number of pending security updates represents known-exploitable surface. NIST 800-53 SI-2 requires the organization to identify, report, and correct flaws in a timely manner. Catching this early keeps the apply-and-test cost low.",
     "fix": "sudo unattended-upgrade -d  # or: sudo apt upgrade  # for security-only the unattended path is preferred"
   },
   "SI-2-security-updates-high": {
-    "family": "SI-2 — Flaw Remediation",
+    "family": "SI-2 \u2014 Flaw Remediation",
     "what": "More than 3 security updates pending",
     "expected": "Apply security updates immediately",
-    "why": "A large security backlog means the host has likely missed at least one published advisory cycle. NIST 800-53 SI-2 requires timely flaw remediation; this is the canonical metric. Schedule the patch window now — every additional day extends the exposure to publicly known vulnerabilities.",
+    "why": "A large security backlog means the host has likely missed at least one published advisory cycle. NIST 800-53 SI-2 requires timely flaw remediation; this is the canonical metric. Schedule the patch window now \u2014 every additional day extends the exposure to publicly known vulnerabilities.",
     "fix": "sudo apt update && sudo unattended-upgrade -d  # follow with: sudo reboot if kernel updates were included"
   },
   "SI-3-clamav-not-installed": {
-    "family": "SI-3 — Malicious Code Protection",
+    "family": "SI-3 \u2014 Malicious Code Protection",
     "what": "ClamAV is not installed",
     "expected": "ClamAV (or another endpoint malware scanner) installed",
     "why": "Without an on-host malware scanner, attached files (downloads, email attachments, agent inputs) are unscreened. NIST 800-53 SI-3 requires malicious code protection. ClamAV is the conventional Linux choice; alternatives are acceptable but Sarge can only attest to ClamAV today.",
     "fix": "sudo apt install clamav clamav-daemon clamav-freshclam"
   },
   "SI-3-clamav-daemon-stopped": {
-    "family": "SI-3 — Malicious Code Protection",
+    "family": "SI-3 \u2014 Malicious Code Protection",
     "what": "ClamAV is installed but clamav-daemon is not running",
     "expected": "clamav-daemon active for on-access scanning",
     "why": "An installed-but-stopped scanner provides no protection. NIST 800-53 SI-3 requires the protection mechanism to actually run. The daemon enables on-access scanning rather than only scheduled batch scans.",
     "fix": "sudo systemctl enable --now clamav-daemon"
   },
   "SI-3-freshclam-stopped": {
-    "family": "SI-3 — Malicious Code Protection",
+    "family": "SI-3 \u2014 Malicious Code Protection",
     "what": "ClamAV signature updater (freshclam) is not running",
     "expected": "clamav-freshclam active to keep signatures current",
     "why": "ClamAV with stale signatures will miss everything published after the last update. NIST 800-53 SI-3 requires malicious code protection mechanisms to be kept current. freshclam handles automatic signature refresh; without it, your scanner ages out of usefulness within days.",
     "fix": "sudo systemctl enable --now clamav-freshclam"
   },
   "SI-3-fail2ban-not-running": {
-    "family": "SI-3 — Malicious Code Protection (extended: brute-force)",
+    "family": "SI-3 \u2014 Malicious Code Protection (extended: brute-force)",
     "what": "fail2ban is not running",
     "expected": "fail2ban active with appropriate jails (sshd, etc.)",
     "why": "fail2ban is the host-side rate-limiter for SSH and other auth daemons; without it, brute-force attempts run as fast as the network allows. NIST 800-53 SI-3 (and IA-2) expect controls against automated credential attacks. fail2ban complements faillock by acting at the network/process layer rather than only at PAM.",
     "fix": "sudo apt install fail2ban && sudo systemctl enable --now fail2ban  # or run scripts/harden-fail2ban.sh"
   },
   "SI-7-checksum-mismatch": {
-    "family": "SI-7 — Software, Firmware, and Information Integrity",
+    "family": "SI-7 \u2014 Software, Firmware, and Information Integrity",
     "what": "Sarge script checksum verification FAILED",
     "expected": "All files listed in CHECKSUMS.sha256 match their recorded hashes",
-    "why": "A checksum mismatch means a sarge script has been modified since the checksum was recorded — either an authorized update (in which case the checksum file is stale) or unauthorized tampering. NIST 800-53 SI-7 requires integrity verification of system software. Sarge is itself a security tool; tampering with it could mute the very findings it should report.",
+    "why": "A checksum mismatch means a sarge script has been modified since the checksum was recorded \u2014 either an authorized update (in which case the checksum file is stale) or unauthorized tampering. NIST 800-53 SI-7 requires integrity verification of system software. Sarge is itself a security tool; tampering with it could mute the very findings it should report.",
     "fix": "Re-clone the sarge repo from a trusted source, or if the change was intentional: regenerate checksums with: sha256sum scripts/*.sh assessment/**/*.sh > CHECKSUMS.sha256"
   },
   "WIN-AC-3-workspace-acl": {
@@ -717,49 +717,48 @@
     "fix": "Not applicable - informational only. Inspect policy-inventory.json in the run folder for the captured settings.",
     "severity": "info"
   },
-
   "AS-1-tool-gate-installed": {
-    "family": "AS-1 — Tool-Gate Hook Installation (Sarge/OpenClaw overlay; maps to AC-3, AC-6)",
+    "family": "AS-1 \u2014 Tool-Gate Hook Installation (Sarge/OpenClaw overlay; maps to AC-3, AC-6)",
     "what": "tool-gate.py + taint-record.py missing from ~/.claude/hooks/, or hook files present but not referenced from ~/.claude/settings.json",
     "expected": "Both hook files present, executable, AND referenced from hooks.PreToolUse (tool-gate.py) / hooks.PostToolUse (taint-record.py) in ~/.claude/settings.json",
-    "why": "Tool-gate is the OpenClaw enforcement point for AC-3 (access enforcement — blocks privileged writes driven by untrusted input) and AC-6 (least privilege — origin-scoped tool routing). A hook file that isn't wired into settings never fires; a settings entry pointing at a missing file crashes the runtime. Either state removes the enforcement layer without any indication in normal operation.",
+    "why": "Tool-gate is the OpenClaw enforcement point for AC-3 (access enforcement \u2014 blocks privileged writes driven by untrusted input) and AC-6 (least privilege \u2014 origin-scoped tool routing). A hook file that isn't wired into settings never fires; a settings entry pointing at a missing file crashes the runtime. Either state removes the enforcement layer without any indication in normal operation.",
     "fix": "Reinstall tool-gate: cp /home/oscar/openclaw/security/tool-gate/tool-gate.py /home/oscar/openclaw/security/tool-gate/taint-record.py /home/oscar/openclaw/security/tool-gate/gate_common.py ~/.claude/hooks/  && verify ~/.claude/settings.json contains hooks.PreToolUse -> tool-gate.py and hooks.PostToolUse -> taint-record.py",
     "scope": "agent"
   },
   "AS-2-gate-mode": {
-    "family": "AS-2 — Tool-Gate Enforcement Mode (Sarge/OpenClaw overlay; maps to AC-3, CM-6)",
+    "family": "AS-2 \u2014 Tool-Gate Enforcement Mode (Sarge/OpenClaw overlay; maps to AC-3, CM-6)",
     "what": "~/.config/o6-gate-mode is missing, is 'shadow' (log-only), or contains an unknown value",
     "expected": "'tier-c' (block Tier-C actions) or 'tier-bc' (block Tier-B and Tier-C). 'shadow' is acceptable during initial rollout only.",
-    "why": "The mode file is the single source of truth for whether tool-gate enforces or merely observes. Missing = no explicit mode (dangerous — a caller may assume enforcement is on); 'shadow' = decisions logged but nothing blocked. Both leave the AC-3 enforcement claim without a control behind it.",
+    "why": "The mode file is the single source of truth for whether tool-gate enforces or merely observes. Missing = no explicit mode (dangerous \u2014 a caller may assume enforcement is on); 'shadow' = decisions logged but nothing blocked. Both leave the AC-3 enforcement claim without a control behind it.",
     "fix": "echo 'tier-c' > ~/.config/o6-gate-mode  # or 'tier-bc' for stricter enforcement once you've had a clean shadow-mode window",
     "scope": "agent"
   },
   "AS-3-decisions-ledger-perm": {
-    "family": "AS-3 — Tool-Gate Decisions Ledger (Sarge/OpenClaw overlay; maps to AU-2, AU-9)",
+    "family": "AS-3 \u2014 Tool-Gate Decisions Ledger (Sarge/OpenClaw overlay; maps to AU-2, AU-9)",
     "what": "~/.openclaw/state/tool-gate/decisions.jsonl missing, or permissions are not 600/400",
     "expected": "File exists with permissions 600 (or 400) and is owned by the operator",
-    "why": "decisions.jsonl is tool-gate's audit trail — every tool call, taint classification, and block decision. Missing = no audit trail (violates AU-2 — auditable events must be recorded). Weak permissions = a local process can tamper with or read gate reasoning (violates AU-9 — protection of audit information).",
+    "why": "decisions.jsonl is tool-gate's audit trail \u2014 every tool call, taint classification, and block decision. Missing = no audit trail (violates AU-2 \u2014 auditable events must be recorded). Weak permissions = a local process can tamper with or read gate reasoning (violates AU-9 \u2014 protection of audit information).",
     "fix": "chmod 600 ~/.openclaw/state/tool-gate/decisions.jsonl  # if missing, run any Claude Code invocation to initialize it",
     "scope": "agent"
   },
   "AS-3-decisions-ledger-fresh": {
-    "family": "AS-3 — Tool-Gate Decisions Ledger (Sarge/OpenClaw overlay; maps to AU-2)",
+    "family": "AS-3 \u2014 Tool-Gate Decisions Ledger (Sarge/OpenClaw overlay; maps to AU-2)",
     "what": "decisions.jsonl has not been modified in the last 7 days",
     "expected": "Ledger modified within the last 7 days (evidence the hook is still firing)",
-    "why": "A stale ledger on an active host means tool-gate has silently stopped firing — the hook file could be there, referenced, and still not running (permission drift, python interpreter gone, settings.json syntax error swallowed). AU-2 requires the events to actually be recorded, not just recordable.",
+    "why": "A stale ledger on an active host means tool-gate has silently stopped firing \u2014 the hook file could be there, referenced, and still not running (permission drift, python interpreter gone, settings.json syntax error swallowed). AU-2 requires the events to actually be recorded, not just recordable.",
     "fix": "Verify PreToolUse hook fires: run any Claude Code interaction, then check `stat ~/.openclaw/state/tool-gate/decisions.jsonl` for a fresh mtime. Also verify ~/.claude/settings.json has valid JSON and hooks.PreToolUse still references tool-gate.py.",
     "scope": "agent"
   },
   "AS-4-digest-cron": {
-    "family": "AS-4 — Tool-Gate Daily Digest (Sarge/OpenClaw overlay; maps to SI-4, AU-6)",
+    "family": "AS-4 \u2014 Tool-Gate Daily Digest (Sarge/OpenClaw overlay; maps to SI-4, AU-6)",
     "what": "gate-digest.sh is not registered in crontab",
     "expected": "A crontab entry runs ~/.claude/hooks/gate-digest.sh --post at least once per day",
-    "why": "gate-digest.sh summarizes would-block events (shadow-mode) and enforcement outcomes and posts them to Discord. Without it, the tool-gate signal is invisible to operators — SI-4 (system monitoring) has no reporting surface, and AU-6 (audit review) never happens.",
+    "why": "gate-digest.sh summarizes would-block events (shadow-mode) and enforcement outcomes and posts them to Discord. Without it, the tool-gate signal is invisible to operators \u2014 SI-4 (system monitoring) has no reporting surface, and AU-6 (audit review) never happens.",
     "fix": "crontab -e  # add: 0 8 * * * /home/oscar/.claude/hooks/gate-digest.sh --post >> /home/oscar/.openclaw/state/tool-gate/digest.log 2>&1",
     "scope": "agent"
   },
   "AS-5-gate-common-integrity": {
-    "family": "AS-5 — gate_common.py Integrity (Sarge/OpenClaw overlay; maps to SI-7, CM-6)",
+    "family": "AS-5 \u2014 gate_common.py Integrity (Sarge/OpenClaw overlay; maps to SI-7, CM-6)",
     "what": "Deployed ~/.claude/hooks/gate_common.py differs from upstream ~/openclaw/security/tool-gate/gate_common.py",
     "expected": "SHA-256 of deployed file matches upstream reference",
     "why": "gate_common.py defines SENSITIVE_WRITE_PATHS and taint-promotion logic. A tampered copy could silently narrow the gate (remove a path, weaken a promotion rule) without changing observable behavior on benign calls. SI-7 (software integrity) requires detection of unauthorized changes; CM-6 (config settings) requires the enforcement config to match the approved baseline.",
@@ -767,15 +766,15 @@
     "scope": "agent"
   },
   "AS-6-attestations-dir-perm": {
-    "family": "AS-6 — Workspace Attestations (Sarge/OpenClaw overlay; maps to CM-2, SI-7)",
+    "family": "AS-6 \u2014 Workspace Attestations (Sarge/OpenClaw overlay; maps to CM-2, SI-7)",
     "what": "~/.openclaw/workspace-attestations/ missing, or permissions are not 700",
     "expected": "Directory exists with permissions 700, owned by the operator",
-    "why": "workspace-attestations/ records signed attestations of workspace canon (SOUL.md, USER.md, AGENTS.md) — the baseline against which drift is measured. Missing = no CM-2 baseline. World/group-readable = a local process can enumerate every attested state, weakening the SI-7 integrity claim.",
+    "why": "workspace-attestations/ records signed attestations of workspace canon (SOUL.md, USER.md, AGENTS.md) \u2014 the baseline against which drift is measured. Missing = no CM-2 baseline. World/group-readable = a local process can enumerate every attested state, weakening the SI-7 integrity claim.",
     "fix": "mkdir -p ~/.openclaw/workspace-attestations && chmod 700 ~/.openclaw/workspace-attestations  # if OpenClaw has never run an attestation, trigger one via the workspace-attest workflow",
     "scope": "agent"
   },
   "AS-6-attestations-fresh": {
-    "family": "AS-6 — Workspace Attestations (Sarge/OpenClaw overlay; maps to CM-2, SI-7)",
+    "family": "AS-6 \u2014 Workspace Attestations (Sarge/OpenClaw overlay; maps to CM-2, SI-7)",
     "what": "No attestation file present, or the newest attestation is older than 30 days",
     "expected": "At least one *.attested file, newest modified within the last 30 days",
     "why": "A workspace-attestation baseline is only meaningful while it reflects the currently intended state. Stale attestations mean drift comparisons chase noise instead of real changes. CM-2 requires baselines to be reviewed on a defined cadence.",
@@ -783,15 +782,15 @@
     "scope": "agent"
   },
   "AS-7-workshop-present": {
-    "family": "AS-7 — Skill-Workshop Review Gate (Sarge/OpenClaw overlay; maps to CM-5, CM-7)",
+    "family": "AS-7 \u2014 Skill-Workshop Review Gate (Sarge/OpenClaw overlay; maps to CM-5, CM-7)",
     "what": "~/.openclaw/skill-workshop/ missing, or proposals/ subdirectory missing",
     "expected": "skill-workshop/ present with proposals/ subdirectory initialized (review queue available for new skills)",
-    "why": "Skill-workshop is the review-gated ingestion point for new skills (added in the OpenClaw 5.7 -> 6.x upgrade). Without it, ClawHub or ad-hoc skills install directly with no operator review — CM-5 (access restrictions for change) collapses, and CM-7 (least functionality) has no gate to enforce.",
+    "why": "Skill-workshop is the review-gated ingestion point for new skills (added in the OpenClaw 5.7 -> 6.x upgrade). Without it, ClawHub or ad-hoc skills install directly with no operator review \u2014 CM-5 (access restrictions for change) collapses, and CM-7 (least functionality) has no gate to enforce.",
     "fix": "Upgrade OpenClaw to a version that ships the skill-workshop primitive (>= 6.x), then enable it in config (workshop.enabled: true). See project_openclaw_upgrade_skill_workshop.md.",
     "scope": "agent"
   },
   "AS-8-cron-trust-perm": {
-    "family": "AS-8 — Cron-Trust Registration (Sarge/OpenClaw overlay; maps to CM-6, AU-2)",
+    "family": "AS-8 \u2014 Cron-Trust Registration (Sarge/OpenClaw overlay; maps to CM-6, AU-2)",
     "what": "~/.openclaw/state/tool-gate/cron-trust.json missing, or permissions are not 600/400",
     "expected": "File exists with permissions 600 (or 400) and is owned by the operator",
     "why": "cron-trust.json is the allowlist tool-gate consults to decide whether a cron-triggered tool call counts as trusted-origin (operator-installed cadence) or external-origin (block Tier-B/C). Missing = every cron job is treated as external and legitimate cadences fail. World/group-writable = a local process can silently add itself to the trusted-origin list.",
@@ -799,7 +798,7 @@
     "scope": "agent"
   },
   "AS-8-cron-trust-coverage": {
-    "family": "AS-8 — Cron-Trust Registration (Sarge/OpenClaw overlay; maps to CM-6, AU-2)",
+    "family": "AS-8 \u2014 Cron-Trust Registration (Sarge/OpenClaw overlay; maps to CM-6, AU-2)",
     "what": "One or more crontab entries reference openclaw / claude / gateway pathways without setting CRON_JOB_NAME",
     "expected": "Every runtime-related crontab entry declares CRON_JOB_NAME=<key> so tool-gate can look the entry up in cron-trust.json",
     "why": "Per feedback_cron_jobs_need_gate_registration.md, unregistered crons cost 266 false-positive taint promotions before the gap was noticed. CM-6 (config settings) requires the enforcement config to be complete for the assets it protects, and AU-2 needs the cron identity in the audit trail.",
@@ -807,7 +806,7 @@
     "scope": "agent"
   },
   "SA-9-external-mcp-servers": {
-    "family": "SA-9 — External System Services",
+    "family": "SA-9 \u2014 External System Services",
     "what": "One or more external MCP servers / API dependencies are configured under mcp.servers in the live OpenClaw config",
     "expected": "Every configured MCP server has a documented data-sharing agreement / risk review, or is removed if no longer needed",
     "why": "SA-9 requires organizations to identify external system services and the risks they introduce before relying on them. Each MCP server is a trust boundary the agent reaches across at runtime; an unreviewed server can exfiltrate data or be a supply-chain pivot point.",
@@ -815,23 +814,23 @@
     "scope": "agent"
   },
   "SA-22-ubuntu-eol": {
-    "family": "SA-22 — Unsupported System Components",
+    "family": "SA-22 \u2014 Unsupported System Components",
     "what": "The host's Ubuntu release is past end-of-life, or within 6 months of reaching it",
     "expected": "Running an Ubuntu LTS release with more than 6 months of standard support remaining",
-    "why": "SA-22 prohibits running unsupported system components — once a release passes EOL, it stops receiving security patches, so any newly disclosed kernel or userspace CVE goes unfixed indefinitely.",
+    "why": "SA-22 prohibits running unsupported system components \u2014 once a release passes EOL, it stops receiving security patches, so any newly disclosed kernel or userspace CVE goes unfixed indefinitely.",
     "fix": "Plan an in-place upgrade to the next Ubuntu LTS release (sudo do-release-upgrade) well before the EOL date.",
     "scope": "host"
   },
   "SA-22-node-eol": {
-    "family": "SA-22 — Unsupported System Components",
+    "family": "SA-22 \u2014 Unsupported System Components",
     "what": "The installed Node.js major version is past end-of-life, or within 6 months of reaching it",
     "expected": "Running a Node.js major version with more than 6 months of upstream support remaining",
-    "why": "SA-22 prohibits running unsupported system components — Node.js majors stop receiving security backports after EOL, and OpenClaw's runtime depends on Node for the gateway and MCP tooling.",
+    "why": "SA-22 prohibits running unsupported system components \u2014 Node.js majors stop receiving security backports after EOL, and OpenClaw's runtime depends on Node for the gateway and MCP tooling.",
     "fix": "Upgrade to a currently supported Node.js LTS line (e.g. via nvm: nvm install --lts && nvm alias default lts/*).",
     "scope": "host"
   },
   "MP-6-media-ttl": {
-    "family": "MP-6 — Media Sanitization",
+    "family": "MP-6 \u2014 Media Sanitization",
     "what": "media.ttlHours is unset or 0 in the live OpenClaw config",
     "expected": "media.ttlHours set to a positive value defining how long generated/received media is retained before cleanup",
     "why": "MP-6 requires media to be sanitized before it's no longer needed. Without a TTL, images/audio/video/downloads the agent handles accumulate on disk indefinitely, expanding the blast radius of a later compromise.",
@@ -839,7 +838,7 @@
     "scope": "agent"
   },
   "MP-6-media-max-size": {
-    "family": "MP-6 — Media Sanitization",
+    "family": "MP-6 \u2014 Media Sanitization",
     "what": "media.maxSizeMb is not set in the live OpenClaw config",
     "expected": "media.maxSizeMb set to a bounded value",
     "why": "Even with a TTL configured, an unbounded max size lets a burst of large media sit at rest for the full retention window, increasing both storage exposure and the amount of sensitive content a compromise could reach. Secondary indicator for MP-6.",
@@ -847,15 +846,15 @@
     "scope": "agent"
   },
   "SR-11-skill-attribution": {
-    "family": "SR-11 — Component Authenticity",
+    "family": "SR-11 \u2014 Component Authenticity",
     "what": "One or more installed skills under the skills directory have no source/author/origin/publisher metadata in SKILL.md",
     "expected": "Every installed skill's SKILL.md declares where it came from (source, origin, author, or publisher)",
-    "why": "SR-11 requires verifying the authenticity of system components before they're trusted. A skill with no attribution can't be traced back to a maintainer or reviewed for tampering — exactly the supply-chain blind spot SR-11 targets.",
+    "why": "SR-11 requires verifying the authenticity of system components before they're trusted. A skill with no attribution can't be traced back to a maintainer or reviewed for tampering \u2014 exactly the supply-chain blind spot SR-11 targets.",
     "fix": "Add a source/author/origin field to the SKILL.md front matter for each flagged skill, or remove skills that can't be attributed.",
     "scope": "agent"
   },
   "SR-11-apt-signing-keys": {
-    "family": "SR-11 — Component Authenticity",
+    "family": "SR-11 \u2014 Component Authenticity",
     "what": "No APT trusted GPG key files found under /etc/apt/trusted.gpg.d/ (or the legacy /etc/apt/trusted.gpg keyring)",
     "expected": "At least one trusted GPG key file present so apt can verify package signatures",
     "why": "SR-11 requires verifying component authenticity through the supply chain; APT's GPG keyring is the mechanism that lets the package manager reject tampered or unsigned .deb packages before install.",
@@ -863,7 +862,7 @@
     "scope": "host"
   },
   "AC-4-network-isolation": {
-    "family": "AC-4 — Information Flow Enforcement",
+    "family": "AC-4 \u2014 Information Flow Enforcement",
     "what": "OpenClaw outbound network access is unrestricted",
     "expected": "network.allowedHosts configured to limit outbound destinations",
     "why": "NIST 800-53 AC-4 requires information flow enforcement. An agent with unrestricted outbound access can exfiltrate data to any destination.",
@@ -871,7 +870,7 @@
     "scope": "agent"
   },
   "AC-5-agent-admin-same-account": {
-    "family": "AC-5 — Separation of Duties",
+    "family": "AC-5 \u2014 Separation of Duties",
     "what": "The account running OpenClaw is also a member of the sudo/admin group",
     "expected": "The OpenClaw agent runs under a dedicated service account that is not the system administrator account",
     "why": "AC-5 requires separating duties so a single compromised identity can't both operate the agent and administer the host. If the agent account has sudo, a prompt-injection or tool-use bug becomes a path to full root.",
@@ -879,7 +878,7 @@
     "scope": "host"
   },
   "AC-7-faillock-deny": {
-    "family": "AC-7 — Unsuccessful Logon Attempts",
+    "family": "AC-7 \u2014 Unsuccessful Logon Attempts",
     "what": "pam_faillock is configured but the deny threshold is weak or unset",
     "expected": "faillock.conf deny set to 3 or more failed attempts before lockout",
     "why": "AC-7 requires the system to enforce a limit on consecutive invalid logon attempts. A missing or overly permissive deny threshold leaves accounts open to online brute-force guessing.",
@@ -887,7 +886,7 @@
     "scope": "host"
   },
   "AC-7-faillock-not-configured": {
-    "family": "AC-7 — Unsuccessful Logon Attempts",
+    "family": "AC-7 \u2014 Unsuccessful Logon Attempts",
     "what": "pam_faillock is not referenced in /etc/pam.d/common-auth",
     "expected": "pam_faillock enabled in common-auth so failed logons trigger a temporary lockout",
     "why": "AC-7 requires the system to enforce a limit on consecutive invalid logon attempts. With no lockout mechanism configured, an attacker can brute-force credentials with no rate limiting at the OS layer.",
@@ -895,7 +894,7 @@
     "scope": "host"
   },
   "AC-8-ssh-banner": {
-    "family": "AC-8 — System Use Notification",
+    "family": "AC-8 \u2014 System Use Notification",
     "what": "No SSH Banner directive is configured in sshd_config",
     "expected": "A Banner directive pointing to a system-use notification file, displayed before authentication",
     "why": "AC-8 requires a system-use notification presented to users before they gain access, establishing legal/authorized-use notice. Without a banner, the host offers no acceptable-use warning to anyone connecting via SSH.",
@@ -903,7 +902,7 @@
     "scope": "host"
   },
   "AC-10-maxlogins": {
-    "family": "AC-10 — Concurrent Session Control",
+    "family": "AC-10 \u2014 Concurrent Session Control",
     "what": "No maxlogins limit is set in /etc/security/limits.conf",
     "expected": "A maxlogins entry bounding the number of concurrent sessions per user",
     "why": "AC-10 requires limiting the number of concurrent sessions for each account. Unbounded concurrent sessions widen the window an attacker with stolen credentials can operate in parallel with the legitimate user.",
@@ -911,7 +910,7 @@
     "scope": "host"
   },
   "AC-11-session-timeout": {
-    "family": "AC-11 — Device Lock",
+    "family": "AC-11 \u2014 Device Lock",
     "what": "No TMOUT (shell idle timeout) is configured",
     "expected": "TMOUT set in /etc/profile or /etc/profile.d/ so idle interactive shells auto-terminate",
     "why": "AC-11 requires the system to initiate a device lock after a period of inactivity. Without TMOUT, an idle authenticated shell stays open indefinitely, exposed to anyone with physical or session access.",
@@ -919,7 +918,7 @@
     "scope": "host"
   },
   "AC-12-session-idle-timeout": {
-    "family": "AC-12 — Session Termination",
+    "family": "AC-12 \u2014 Session Termination",
     "what": "sessions.idleTimeoutMinutes is not set in the live OpenClaw config",
     "expected": "sessions.idleTimeoutMinutes set to a bounded value",
     "why": "AC-12 requires automatic session termination after a defined idle period. Without it, an OpenClaw session can sit open indefinitely, extending the window an attacker who hijacks it has to act.",
@@ -927,15 +926,15 @@
     "scope": "agent"
   },
   "AC-14-auth-disabled": {
-    "family": "AC-14 — Permitted Actions Without Identification or Authentication",
+    "family": "AC-14 \u2014 Permitted Actions Without Identification or Authentication",
     "what": "OpenClaw's auth.enabled is false, or not explicitly set, in the live config",
     "expected": "auth.enabled explicitly set to true so gateway actions require identification/authentication",
-    "why": "AC-14 requires organizations to explicitly identify and document any actions permitted without authentication — everything else must require it. A gateway with auth disabled (or unstated) accepts commands from anyone who can reach it.",
+    "why": "AC-14 requires organizations to explicitly identify and document any actions permitted without authentication \u2014 everything else must require it. A gateway with auth disabled (or unstated) accepts commands from anyone who can reach it.",
     "fix": "Set auth.enabled to true in openclaw.json and configure at least one auth provider.",
     "scope": "agent"
   },
   "CM-3-change-control": {
-    "family": "CM-3 — Configuration Change Control",
+    "family": "CM-3 \u2014 Configuration Change Control",
     "what": "~/.openclaw is not under version control and no Sarge drift snapshot exists",
     "expected": "Either ~/.openclaw is a git working tree, or a Sarge drift snapshot baseline has been captured",
     "why": "CM-3 requires a documented process for tracking and reviewing configuration changes. Without version control or a drift baseline, config changes happen silently and can't be attributed, reviewed, or rolled back.",
@@ -943,7 +942,7 @@
     "scope": "agent"
   },
   "CM-5-config-owner": {
-    "family": "CM-5 — Access Restrictions for Change",
+    "family": "CM-5 \u2014 Access Restrictions for Change",
     "what": "The live OpenClaw config file is not owned by the account that runs OpenClaw",
     "expected": "openclaw.json (or config.json) owned by the OpenClaw agent's own user account",
     "why": "CM-5 requires restricting who can make configuration changes to authorized individuals/processes. A config owned by a different account (especially root) either blocks legitimate self-service changes or signals the file was placed by a process outside the agent's own control.",
@@ -951,7 +950,7 @@
     "scope": "agent"
   },
   "CM-8-component-inventory": {
-    "family": "CM-8 — System Component Inventory",
+    "family": "CM-8 \u2014 System Component Inventory",
     "what": "Informational snapshot of installed components: Node.js runtime version, configured MCP servers, and configured plugins",
     "expected": "The reported inventory matches an approved/expected component list for this host",
     "why": "CM-8 requires maintaining an inventory of system components. This finding surfaces what Sarge could enumerate so operators can reconcile it against their own change-management records rather than discover drift after the fact.",
@@ -959,11 +958,67 @@
     "scope": "agent"
   },
   "CM-11-global-npm-packages": {
-    "family": "CM-11 — User-Installed Software",
+    "family": "CM-11 \u2014 User-Installed Software",
     "what": "Global npm packages are installed outside the OpenClaw dependency tree",
     "expected": "No unreviewed global npm packages present, or all of them are explicitly approved",
     "why": "CM-11 requires controlling user-installed software. Globally-installed npm packages bypass package.json-tracked dependency review and can introduce unreviewed code with broad filesystem/network access.",
     "fix": "Run 'npm list -g --depth=0', review each entry, and 'npm uninstall -g <package>' anything not explicitly approved.",
     "scope": "host"
+  },
+  "SC-2-process-isolation": {
+    "family": "SC-2 \u2014 Application Partitioning",
+    "what": "OpenClaw is running as root",
+    "expected": "OpenClaw runs under a dedicated non-root service account",
+    "why": "NIST 800-53 SC-2 requires separation between user-facing and system management functionality. Running the agent as root gives it unrestricted access to the entire system, violating least privilege and increasing blast radius of any compromise.",
+    "fix": "Create a dedicated service account (e.g. 'openclaw') and run the gateway under that account: sudo -u openclaw openclaw gateway start"
+  },
+  "SC-2-namespace-isolation": {
+    "family": "SC-2 \u2014 Application Partitioning",
+    "what": "OpenClaw shares the host mount namespace",
+    "expected": "OpenClaw runs in an isolated namespace or container",
+    "why": "Namespace isolation limits the agent's view of the filesystem and process tree. Without it, a compromised agent can access any host file.",
+    "fix": "Run OpenClaw in a container, or use unshare/systemd namespace features to isolate its mount namespace."
+  },
+  "SC-4-tmp-residual": {
+    "family": "SC-4 \u2014 Information in Shared Resources",
+    "what": "Excessive OpenClaw/Claude temp files in /tmp",
+    "expected": "Temp files cleaned up after session ends",
+    "why": "NIST 800-53 SC-4 requires preventing unauthorized information transfer via shared resources. Residual session data in /tmp may contain conversation fragments, tool outputs, or credentials from prior runs.",
+    "fix": "Configure a systemd-tmpfiles.d rule or cron to clean /tmp/claude-* and /tmp/openclaw-* periodically."
+  },
+  "SC-4-shm-residual": {
+    "family": "SC-4 \u2014 Information in Shared Resources",
+    "what": "Files present in /dev/shm shared memory",
+    "expected": "No unexpected files in /dev/shm",
+    "why": "Shared memory is world-readable by default. Sensitive data left in /dev/shm can be read by any process on the host.",
+    "fix": "Review and remove unnecessary files from /dev/shm. Ensure applications clean up shared memory segments on exit."
+  },
+  "SC-12-key-permissions": {
+    "family": "SC-12 \u2014 Cryptographic Key Establishment and Management",
+    "what": "Key or credential files under ~/.openclaw/secrets/ have weak permissions",
+    "expected": "All key/credential files are 600 or 400",
+    "why": "NIST 800-53 SC-12 requires managing cryptographic keys throughout their lifecycle. Files with permissions broader than 600 allow other users on the system to read key material.",
+    "fix": "chmod 600 ~/.openclaw/secrets/<file>"
+  },
+  "SC-12-ssh-key-permissions": {
+    "family": "SC-12 \u2014 Cryptographic Key Establishment and Management",
+    "what": "SSH private keys have weak permissions",
+    "expected": "SSH private keys are 600 or 400",
+    "why": "SSH private keys with overly permissive modes can be read by other users. SSH itself refuses to use keys with bad permissions, but the key material is still exposed.",
+    "fix": "chmod 600 ~/.ssh/id_*"
+  },
+  "SC-13-openssl-version": {
+    "family": "SC-13 \u2014 Cryptographic Protection",
+    "what": "OpenSSL version may not meet cryptographic requirements",
+    "expected": "OpenSSL 1.1+ or 3.x (FIPS-capable)",
+    "why": "NIST 800-53 SC-13 requires FIPS-validated cryptography for federal systems. OpenSSL 3.x includes a FIPS provider module; older versions may not support required algorithms or modes.",
+    "fix": "Upgrade to OpenSSL 3.x: sudo apt install openssl"
+  },
+  "SC-13-node-tls": {
+    "family": "SC-13 \u2014 Cryptographic Protection",
+    "what": "Node.js version may not enforce TLS 1.2+ by default",
+    "expected": "Node.js 18+ (uses OpenSSL 3.x, TLS 1.2+ default min)",
+    "why": "Node.js versions below 18 use OpenSSL 1.x and may negotiate TLS 1.0/1.1, which have known weaknesses. NIST 800-53 SC-13 requires approved cryptographic mechanisms.",
+    "fix": "Upgrade to Node.js 18 LTS or later."
   }
 }

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -805,5 +805,61 @@
     "why": "Per feedback_cron_jobs_need_gate_registration.md, unregistered crons cost 266 false-positive taint promotions before the gap was noticed. CM-6 (config settings) requires the enforcement config to be complete for the assets it protects, and AU-2 needs the cron identity in the audit trail.",
     "fix": "For each flagged crontab line, add a CRON_JOB_NAME assignment (e.g. `CRON_JOB_NAME=my-cadence /path/to/script.sh`) and a matching entry in ~/.openclaw/state/tool-gate/cron-trust.json with the right tier gate.",
     "scope": "agent"
+  },
+  "SA-9-external-mcp-servers": {
+    "family": "SA-9 — External System Services",
+    "what": "One or more external MCP servers / API dependencies are configured under mcp.servers in the live OpenClaw config",
+    "expected": "Every configured MCP server has a documented data-sharing agreement / risk review, or is removed if no longer needed",
+    "why": "SA-9 requires organizations to identify external system services and the risks they introduce before relying on them. Each MCP server is a trust boundary the agent reaches across at runtime; an unreviewed server can exfiltrate data or be a supply-chain pivot point.",
+    "fix": "Review each listed MCP server's URL/provider for a data-sharing agreement and least-privilege scope. Remove entries from mcp.servers that are no longer required.",
+    "scope": "agent"
+  },
+  "SA-22-ubuntu-eol": {
+    "family": "SA-22 — Unsupported System Components",
+    "what": "The host's Ubuntu release is past end-of-life, or within 6 months of reaching it",
+    "expected": "Running an Ubuntu LTS release with more than 6 months of standard support remaining",
+    "why": "SA-22 prohibits running unsupported system components — once a release passes EOL, it stops receiving security patches, so any newly disclosed kernel or userspace CVE goes unfixed indefinitely.",
+    "fix": "Plan an in-place upgrade to the next Ubuntu LTS release (sudo do-release-upgrade) well before the EOL date.",
+    "scope": "host"
+  },
+  "SA-22-node-eol": {
+    "family": "SA-22 — Unsupported System Components",
+    "what": "The installed Node.js major version is past end-of-life, or within 6 months of reaching it",
+    "expected": "Running a Node.js major version with more than 6 months of upstream support remaining",
+    "why": "SA-22 prohibits running unsupported system components — Node.js majors stop receiving security backports after EOL, and OpenClaw's runtime depends on Node for the gateway and MCP tooling.",
+    "fix": "Upgrade to a currently supported Node.js LTS line (e.g. via nvm: nvm install --lts && nvm alias default lts/*).",
+    "scope": "host"
+  },
+  "MP-6-media-ttl": {
+    "family": "MP-6 — Media Sanitization",
+    "what": "media.ttlHours is unset or 0 in the live OpenClaw config",
+    "expected": "media.ttlHours set to a positive value defining how long generated/received media is retained before cleanup",
+    "why": "MP-6 requires media to be sanitized before it's no longer needed. Without a TTL, images/audio/video/downloads the agent handles accumulate on disk indefinitely, expanding the blast radius of a later compromise.",
+    "fix": "Set media.ttlHours to a positive retention window in openclaw.json (e.g. 24-168 depending on workflow needs) and restart the gateway.",
+    "scope": "agent"
+  },
+  "MP-6-media-max-size": {
+    "family": "MP-6 — Media Sanitization",
+    "what": "media.maxSizeMb is not set in the live OpenClaw config",
+    "expected": "media.maxSizeMb set to a bounded value",
+    "why": "Even with a TTL configured, an unbounded max size lets a burst of large media sit at rest for the full retention window, increasing both storage exposure and the amount of sensitive content a compromise could reach. Secondary indicator for MP-6.",
+    "fix": "Set media.maxSizeMb to a reasonable ceiling in openclaw.json based on expected media workflows.",
+    "scope": "agent"
+  },
+  "SR-11-skill-attribution": {
+    "family": "SR-11 — Component Authenticity",
+    "what": "One or more installed skills under the skills directory have no source/author/origin/publisher metadata in SKILL.md",
+    "expected": "Every installed skill's SKILL.md declares where it came from (source, origin, author, or publisher)",
+    "why": "SR-11 requires verifying the authenticity of system components before they're trusted. A skill with no attribution can't be traced back to a maintainer or reviewed for tampering — exactly the supply-chain blind spot SR-11 targets.",
+    "fix": "Add a source/author/origin field to the SKILL.md front matter for each flagged skill, or remove skills that can't be attributed.",
+    "scope": "agent"
+  },
+  "SR-11-apt-signing-keys": {
+    "family": "SR-11 — Component Authenticity",
+    "what": "No APT trusted GPG key files found under /etc/apt/trusted.gpg.d/ (or the legacy /etc/apt/trusted.gpg keyring)",
+    "expected": "At least one trusted GPG key file present so apt can verify package signatures",
+    "why": "SR-11 requires verifying component authenticity through the supply chain; APT's GPG keyring is the mechanism that lets the package manager reject tampered or unsigned .deb packages before install.",
+    "fix": "Reinstall the distribution's default keyring package (ubuntu-keyring) or re-add trusted keys for configured third-party repositories.",
+    "scope": "host"
   }
 }

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -1020,5 +1020,54 @@
     "expected": "Node.js 18+ (uses OpenSSL 3.x, TLS 1.2+ default min)",
     "why": "Node.js versions below 18 use OpenSSL 1.x and may negotiate TLS 1.0/1.1, which have known weaknesses. NIST 800-53 SC-13 requires approved cryptographic mechanisms.",
     "fix": "Upgrade to Node.js 18 LTS or later."
+  },
+  "SC-15-device-access": {
+    "family": "SC-15 \u2014 Collaborative Computing Devices",
+    "what": "Camera, microphone, or screen capture capabilities are enabled for the agent",
+    "expected": "Device capabilities disabled unless explicitly required by the agent's mission",
+    "why": "NIST 800-53 SC-15 requires controlling remote activation of collaborative computing devices. An AI agent with camera/mic access can capture environmental data beyond its intended scope.",
+    "fix": "Remove camera/microphone/screen capabilities from the agent's openclaw.json configuration unless operationally required."
+  },
+  "SC-15-video-devices": {
+    "family": "SC-15 \u2014 Collaborative Computing Devices",
+    "what": "Video capture hardware detected on the host",
+    "expected": "No video devices accessible to the agent, or access explicitly authorized",
+    "why": "Physical video capture devices connected to an agent host expand the agent's potential data collection surface. Verify the agent's access to /dev/video* is intentional.",
+    "fix": "Remove the agent user from the 'video' group, or physically disconnect the camera if not needed."
+  },
+  "SC-23-auth-enabled": {
+    "family": "SC-23 \u2014 Session Authenticity",
+    "what": "OpenClaw authentication is not enabled or not explicitly configured",
+    "expected": "auth.enabled set to true in openclaw.json",
+    "why": "NIST 800-53 SC-23 requires authenticating sessions. Without auth, anyone with network access to the gateway port can create sessions and issue commands to the agent.",
+    "fix": "Set auth.enabled: true in openclaw.json and configure appropriate authentication providers."
+  },
+  "SC-23-gateway-token": {
+    "family": "SC-23 \u2014 Session Authenticity",
+    "what": "No gateway token configured for API access",
+    "expected": "gatewayToken set in openclaw.json",
+    "why": "The gateway token is the primary authentication mechanism for programmatic API access. Without it, the gateway API is open to any caller on the network.",
+    "fix": "Generate a strong random token and set gatewayToken in openclaw.json."
+  },
+  "SC-39-cgroup-isolation": {
+    "family": "SC-39 \u2014 Process Isolation",
+    "what": "OpenClaw process is not in a scoped cgroup or container",
+    "expected": "Agent process runs in a dedicated cgroup slice or container with resource limits",
+    "why": "NIST 800-53 SC-39 requires maintaining separate execution domains. Without cgroup isolation, the agent process can consume unlimited host resources and is not bounded by CPU/memory/IO limits.",
+    "fix": "Run OpenClaw under a systemd slice (systemd-run --scope --slice=openclaw) or in a container with resource limits."
+  },
+  "SC-39-pid-namespace": {
+    "family": "SC-39 \u2014 Process Isolation",
+    "what": "OpenClaw shares the host PID namespace",
+    "expected": "Agent runs in a separate PID namespace",
+    "why": "Sharing the host PID namespace allows the agent to see and potentially signal all host processes. PID namespace isolation limits the agent's process visibility to its own subtree.",
+    "fix": "Run OpenClaw in a container or with unshare --pid to isolate its process namespace."
+  },
+  "SC-39-net-namespace": {
+    "family": "SC-39 \u2014 Process Isolation",
+    "what": "OpenClaw shares the host network namespace",
+    "expected": "Agent runs in a separate network namespace or has firewall-restricted access",
+    "why": "Sharing the host network namespace gives the agent access to all host network interfaces, including internal/management networks. Network namespace isolation limits the agent's network surface.",
+    "fix": "Run OpenClaw in a container with a dedicated network namespace, or use iptables/nftables to restrict the agent user's network access."
   }
 }

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -861,5 +861,109 @@
     "why": "SR-11 requires verifying component authenticity through the supply chain; APT's GPG keyring is the mechanism that lets the package manager reject tampered or unsigned .deb packages before install.",
     "fix": "Reinstall the distribution's default keyring package (ubuntu-keyring) or re-add trusted keys for configured third-party repositories.",
     "scope": "host"
+  },
+  "AC-4-network-isolation": {
+    "family": "AC-4 — Information Flow Enforcement",
+    "what": "OpenClaw outbound network access is unrestricted",
+    "expected": "network.allowedHosts configured to limit outbound destinations",
+    "why": "NIST 800-53 AC-4 requires information flow enforcement. An agent with unrestricted outbound access can exfiltrate data to any destination.",
+    "fix": "Add network.allowedHosts to openclaw.json with the list of permitted destinations.",
+    "scope": "agent"
+  },
+  "AC-5-agent-admin-same-account": {
+    "family": "AC-5 — Separation of Duties",
+    "what": "The account running OpenClaw is also a member of the sudo/admin group",
+    "expected": "The OpenClaw agent runs under a dedicated service account that is not the system administrator account",
+    "why": "AC-5 requires separating duties so a single compromised identity can't both operate the agent and administer the host. If the agent account has sudo, a prompt-injection or tool-use bug becomes a path to full root.",
+    "fix": "Create a dedicated non-admin service account for OpenClaw and migrate the deployment to it; remove the current account from the sudo/admin group.",
+    "scope": "host"
+  },
+  "AC-7-faillock-deny": {
+    "family": "AC-7 — Unsuccessful Logon Attempts",
+    "what": "pam_faillock is configured but the deny threshold is weak or unset",
+    "expected": "faillock.conf deny set to 3 or more failed attempts before lockout",
+    "why": "AC-7 requires the system to enforce a limit on consecutive invalid logon attempts. A missing or overly permissive deny threshold leaves accounts open to online brute-force guessing.",
+    "fix": "Set 'deny = 3' (or higher) in /etc/security/faillock.conf.",
+    "scope": "host"
+  },
+  "AC-7-faillock-not-configured": {
+    "family": "AC-7 — Unsuccessful Logon Attempts",
+    "what": "pam_faillock is not referenced in /etc/pam.d/common-auth",
+    "expected": "pam_faillock enabled in common-auth so failed logons trigger a temporary lockout",
+    "why": "AC-7 requires the system to enforce a limit on consecutive invalid logon attempts. With no lockout mechanism configured, an attacker can brute-force credentials with no rate limiting at the OS layer.",
+    "fix": "Add pam_faillock to /etc/pam.d/common-auth (auth required pam_faillock.so preauth / authfail / account required pam_faillock.so) and set a deny threshold in faillock.conf.",
+    "scope": "host"
+  },
+  "AC-8-ssh-banner": {
+    "family": "AC-8 — System Use Notification",
+    "what": "No SSH Banner directive is configured in sshd_config",
+    "expected": "A Banner directive pointing to a system-use notification file, displayed before authentication",
+    "why": "AC-8 requires a system-use notification presented to users before they gain access, establishing legal/authorized-use notice. Without a banner, the host offers no acceptable-use warning to anyone connecting via SSH.",
+    "fix": "Create a banner file (e.g. /etc/issue.net) with system-use notification text and set 'Banner /etc/issue.net' in sshd_config, then restart sshd.",
+    "scope": "host"
+  },
+  "AC-10-maxlogins": {
+    "family": "AC-10 — Concurrent Session Control",
+    "what": "No maxlogins limit is set in /etc/security/limits.conf",
+    "expected": "A maxlogins entry bounding the number of concurrent sessions per user",
+    "why": "AC-10 requires limiting the number of concurrent sessions for each account. Unbounded concurrent sessions widen the window an attacker with stolen credentials can operate in parallel with the legitimate user.",
+    "fix": "Add a line like '* hard maxlogins 3' to /etc/security/limits.conf.",
+    "scope": "host"
+  },
+  "AC-11-session-timeout": {
+    "family": "AC-11 — Device Lock",
+    "what": "No TMOUT (shell idle timeout) is configured",
+    "expected": "TMOUT set in /etc/profile or /etc/profile.d/ so idle interactive shells auto-terminate",
+    "why": "AC-11 requires the system to initiate a device lock after a period of inactivity. Without TMOUT, an idle authenticated shell stays open indefinitely, exposed to anyone with physical or session access.",
+    "fix": "Set 'TMOUT=900' (or your policy's idle window) in /etc/profile.d/tmout.sh and make it readonly/exported.",
+    "scope": "host"
+  },
+  "AC-12-session-idle-timeout": {
+    "family": "AC-12 — Session Termination",
+    "what": "sessions.idleTimeoutMinutes is not set in the live OpenClaw config",
+    "expected": "sessions.idleTimeoutMinutes set to a bounded value",
+    "why": "AC-12 requires automatic session termination after a defined idle period. Without it, an OpenClaw session can sit open indefinitely, extending the window an attacker who hijacks it has to act.",
+    "fix": "Set sessions.idleTimeoutMinutes in openclaw.json to a reasonable idle window (e.g. 30-60 minutes).",
+    "scope": "agent"
+  },
+  "AC-14-auth-disabled": {
+    "family": "AC-14 — Permitted Actions Without Identification or Authentication",
+    "what": "OpenClaw's auth.enabled is false, or not explicitly set, in the live config",
+    "expected": "auth.enabled explicitly set to true so gateway actions require identification/authentication",
+    "why": "AC-14 requires organizations to explicitly identify and document any actions permitted without authentication — everything else must require it. A gateway with auth disabled (or unstated) accepts commands from anyone who can reach it.",
+    "fix": "Set auth.enabled to true in openclaw.json and configure at least one auth provider.",
+    "scope": "agent"
+  },
+  "CM-3-change-control": {
+    "family": "CM-3 — Configuration Change Control",
+    "what": "~/.openclaw is not under version control and no Sarge drift snapshot exists",
+    "expected": "Either ~/.openclaw is a git working tree, or a Sarge drift snapshot baseline has been captured",
+    "why": "CM-3 requires a documented process for tracking and reviewing configuration changes. Without version control or a drift baseline, config changes happen silently and can't be attributed, reviewed, or rolled back.",
+    "fix": "Run 'git init' in ~/.openclaw and commit the current config, and/or run drift/snapshot.sh to establish a Sarge baseline.",
+    "scope": "agent"
+  },
+  "CM-5-config-owner": {
+    "family": "CM-5 — Access Restrictions for Change",
+    "what": "The live OpenClaw config file is not owned by the account that runs OpenClaw",
+    "expected": "openclaw.json (or config.json) owned by the OpenClaw agent's own user account",
+    "why": "CM-5 requires restricting who can make configuration changes to authorized individuals/processes. A config owned by a different account (especially root) either blocks legitimate self-service changes or signals the file was placed by a process outside the agent's own control.",
+    "fix": "chown the config file to the OpenClaw service account: sudo chown <agent-user> ~/.openclaw/openclaw.json.",
+    "scope": "agent"
+  },
+  "CM-8-component-inventory": {
+    "family": "CM-8 — System Component Inventory",
+    "what": "Informational snapshot of installed components: Node.js runtime version, configured MCP servers, and configured plugins",
+    "expected": "The reported inventory matches an approved/expected component list for this host",
+    "why": "CM-8 requires maintaining an inventory of system components. This finding surfaces what Sarge could enumerate so operators can reconcile it against their own change-management records rather than discover drift after the fact.",
+    "fix": "Compare the reported Node.js version, MCP server list, and plugin list against your approved baseline; update the baseline or remediate any unapproved component.",
+    "scope": "agent"
+  },
+  "CM-11-global-npm-packages": {
+    "family": "CM-11 — User-Installed Software",
+    "what": "Global npm packages are installed outside the OpenClaw dependency tree",
+    "expected": "No unreviewed global npm packages present, or all of them are explicitly approved",
+    "why": "CM-11 requires controlling user-installed software. Globally-installed npm packages bypass package.json-tracked dependency review and can introduce unreviewed code with broad filesystem/network access.",
+    "fix": "Run 'npm list -g --depth=0', review each entry, and 'npm uninstall -g <package>' anything not explicitly approved.",
+    "scope": "host"
   }
 }

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -9,8 +9,15 @@
       "family": "AC",
       "name": "Account Management",
       "status": "full",
-      "openclaw_settings": ["agents.allowlist", "channels.*.allowedUsers"],
-      "os_checks": ["getent passwd", "lastlog", "who"],
+      "openclaw_settings": [
+        "agents.allowlist",
+        "channels.*.allowedUsers"
+      ],
+      "os_checks": [
+        "getent passwd",
+        "lastlog",
+        "who"
+      ],
       "remediation": "Remove unused accounts. Restrict OpenClaw allowlist to named users only."
     },
     {
@@ -18,8 +25,14 @@
       "family": "AC",
       "name": "Access Enforcement",
       "status": "full",
-      "openclaw_settings": ["tools.fs.workspaceOnly", "agents.defaults.sandbox.mode"],
-      "os_checks": ["file permissions on ~/.openclaw/", "sudoers review"],
+      "openclaw_settings": [
+        "tools.fs.workspaceOnly",
+        "agents.defaults.sandbox.mode"
+      ],
+      "os_checks": [
+        "file permissions on ~/.openclaw/",
+        "sudoers review"
+      ],
       "remediation": "Set workspaceOnly=true. Set sandbox mode to all. Restrict sudoers."
     },
     {
@@ -27,8 +40,14 @@
       "family": "AC",
       "name": "Least Privilege",
       "status": "full",
-      "openclaw_settings": ["tools.exec.elevated", "agents.defaults.sandbox.mode"],
-      "os_checks": ["sudo -l", "groups <user>"],
+      "openclaw_settings": [
+        "tools.exec.elevated",
+        "agents.defaults.sandbox.mode"
+      ],
+      "os_checks": [
+        "sudo -l",
+        "groups <user>"
+      ],
       "remediation": "Disable elevated exec unless required. Confirm service account has no unnecessary group memberships."
     },
     {
@@ -36,8 +55,14 @@
       "family": "AC",
       "name": "Remote Access",
       "status": "full",
-      "openclaw_settings": ["gateway.bind", "gateway.remote.url"],
-      "os_checks": ["ufw status", "ss -tlnp"],
+      "openclaw_settings": [
+        "gateway.bind",
+        "gateway.remote.url"
+      ],
+      "os_checks": [
+        "ufw status",
+        "ss -tlnp"
+      ],
       "remediation": "Set gateway.bind to lan. Use Cloudflare Tunnel for remote access only."
     },
     {
@@ -45,8 +70,14 @@
       "family": "AU",
       "name": "Event Logging",
       "status": "full",
-      "openclaw_settings": ["logging.level", "logging.destination"],
-      "os_checks": ["systemctl status auditd", "auditctl -l"],
+      "openclaw_settings": [
+        "logging.level",
+        "logging.destination"
+      ],
+      "os_checks": [
+        "systemctl status auditd",
+        "auditctl -l"
+      ],
       "remediation": "Enable auditd. Set OpenClaw logging level to info or higher."
     },
     {
@@ -54,8 +85,14 @@
       "family": "AU",
       "name": "Content of Audit Records",
       "status": "full",
-      "openclaw_settings": ["logging.includeTimestamp", "logging.includeUser"],
-      "os_checks": ["ausearch -m LOGIN", "last"],
+      "openclaw_settings": [
+        "logging.includeTimestamp",
+        "logging.includeUser"
+      ],
+      "os_checks": [
+        "ausearch -m LOGIN",
+        "last"
+      ],
       "remediation": "Ensure audit records include timestamp, user, action, and outcome."
     },
     {
@@ -64,7 +101,10 @@
       "name": "Audit Log Storage Capacity",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["df -P /var/log/audit", "df -P /var/log"],
+      "os_checks": [
+        "df -P /var/log/audit",
+        "df -P /var/log"
+      ],
       "remediation": "Ensure the audit log partition retains at least 10% free space. Configure log rotation with adequate headroom or expand storage."
     },
     {
@@ -73,7 +113,10 @@
       "name": "Response to Audit Processing Failures",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep disk_full_action /etc/audit/auditd.conf", "grep admin_space_left_action /etc/audit/auditd.conf"],
+      "os_checks": [
+        "grep disk_full_action /etc/audit/auditd.conf",
+        "grep admin_space_left_action /etc/audit/auditd.conf"
+      ],
       "remediation": "Set disk_full_action and admin_space_left_action in auditd.conf to something other than IGNORE (e.g. SYSLOG, EMAIL, HALT)."
     },
     {
@@ -82,7 +125,11 @@
       "name": "Audit Record Reduction and Report Generation",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["which journalctl", "which ausearch", "grep -r '@' /etc/rsyslog.d/"],
+      "os_checks": [
+        "which journalctl",
+        "which ausearch",
+        "grep -r '@' /etc/rsyslog.d/"
+      ],
       "remediation": "Install auditd (provides ausearch) or configure rsyslog forwarding so audit records can be queried and aggregated."
     },
     {
@@ -91,7 +138,10 @@
       "name": "Time Stamps",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["timedatectl show -p NTPSynchronized", "chronyc tracking"],
+      "os_checks": [
+        "timedatectl show -p NTPSynchronized",
+        "chronyc tracking"
+      ],
       "remediation": "Enable NTP synchronization: sudo timedatectl set-ntp true."
     },
     {
@@ -100,7 +150,10 @@
       "name": "Protection of Audit Information",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["ls -la /var/log/audit/", "stat /var/log/audit/audit.log"],
+      "os_checks": [
+        "ls -la /var/log/audit/",
+        "stat /var/log/audit/audit.log"
+      ],
       "remediation": "Audit logs must be owned by root, mode 600. Restrict write access."
     },
     {
@@ -109,7 +162,9 @@
       "name": "Audit Record Retention",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep rotate /etc/logrotate.d/auditd"],
+      "os_checks": [
+        "grep rotate /etc/logrotate.d/auditd"
+      ],
       "remediation": "Configure logrotate for audit logs with a 'rotate' count of at least 4 (weekly rotation) to meet minimum retention."
     },
     {
@@ -117,8 +172,12 @@
       "family": "AU",
       "name": "Audit Record Generation",
       "status": "full",
-      "openclaw_settings": ["logging.auditActions"],
-      "os_checks": ["auditctl -l | grep openclaw"],
+      "openclaw_settings": [
+        "logging.auditActions"
+      ],
+      "os_checks": [
+        "auditctl -l | grep openclaw"
+      ],
       "remediation": "Add auditd watch rules for ~/.openclaw/secrets/ and OpenClaw config files."
     },
     {
@@ -126,8 +185,12 @@
       "family": "CA",
       "name": "Internal System Connections",
       "status": "partial",
-      "openclaw_settings": ["mcp.servers"],
-      "os_checks": ["parse ~/.openclaw/openclaw.json mcp.servers"],
+      "openclaw_settings": [
+        "mcp.servers"
+      ],
+      "os_checks": [
+        "parse ~/.openclaw/openclaw.json mcp.servers"
+      ],
       "remediation": "Document each MCP server connection in the system security plan / interconnection agreements. Remove any unused or unauthorized servers."
     },
     {
@@ -135,8 +198,13 @@
       "family": "CM",
       "name": "Baseline Configuration",
       "status": "full",
-      "openclaw_settings": ["*"],
-      "os_checks": ["dpkg --get-selections", "systemctl list-units --state=enabled"],
+      "openclaw_settings": [
+        "*"
+      ],
+      "os_checks": [
+        "dpkg --get-selections",
+        "systemctl list-units --state=enabled"
+      ],
       "remediation": "Maintain openclaw.json.baseline as the documented configuration baseline."
     },
     {
@@ -144,8 +212,15 @@
       "family": "CM",
       "name": "Configuration Settings",
       "status": "full",
-      "openclaw_settings": ["tools.fs.workspaceOnly", "agents.defaults.sandbox.mode", "gateway.bind"],
-      "os_checks": ["ufw status verbose", "sshd -T | grep -i permit"],
+      "openclaw_settings": [
+        "tools.fs.workspaceOnly",
+        "agents.defaults.sandbox.mode",
+        "gateway.bind"
+      ],
+      "os_checks": [
+        "ufw status verbose",
+        "sshd -T | grep -i permit"
+      ],
       "remediation": "Apply all settings in openclaw.json.baseline. Apply all Sarge hardening scripts."
     },
     {
@@ -153,8 +228,14 @@
       "family": "CM",
       "name": "Least Functionality",
       "status": "full",
-      "openclaw_settings": ["plugins.enabled", "tools.enabled"],
-      "os_checks": ["systemctl list-units --state=enabled", "apt list --installed"],
+      "openclaw_settings": [
+        "plugins.enabled",
+        "tools.enabled"
+      ],
+      "os_checks": [
+        "systemctl list-units --state=enabled",
+        "apt list --installed"
+      ],
       "remediation": "Disable unused OpenClaw plugins and tools. Remove unnecessary OS packages."
     },
     {
@@ -163,7 +244,10 @@
       "name": "System Backup",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["crontab -l | grep -i backup", "systemctl list-timers --all | grep -i backup"],
+      "os_checks": [
+        "crontab -l | grep -i backup",
+        "systemctl list-timers --all | grep -i backup"
+      ],
       "remediation": "Configure a scheduled backup (cron or systemd timer) of ~/.openclaw config, secrets, and workspace state. Verify backups are recoverable."
     },
     {
@@ -171,8 +255,13 @@
       "family": "IA",
       "name": "Identification and Authentication (Org Users)",
       "status": "full",
-      "openclaw_settings": ["channels.*.allowedUsers"],
-      "os_checks": ["pam_faillock status", "grep pam_faillock /etc/pam.d/common-auth"],
+      "openclaw_settings": [
+        "channels.*.allowedUsers"
+      ],
+      "os_checks": [
+        "pam_faillock status",
+        "grep pam_faillock /etc/pam.d/common-auth"
+      ],
       "remediation": "Enable PAM faillock. Restrict OpenClaw to authenticated Discord/channel users only."
     },
     {
@@ -181,7 +270,10 @@
       "name": "Authenticator Management",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep minlen /etc/security/pwquality.conf", "grep PASS_MAX_DAYS /etc/login.defs"],
+      "os_checks": [
+        "grep minlen /etc/security/pwquality.conf",
+        "grep PASS_MAX_DAYS /etc/login.defs"
+      ],
       "remediation": "Set pwquality minlen=12, complexity rules. Set PASS_MAX_DAYS=90, PASS_MIN_DAYS=1."
     },
     {
@@ -190,7 +282,9 @@
       "name": "Authentication Feedback",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep pam_unix /etc/pam.d/common-auth"],
+      "os_checks": [
+        "grep pam_unix /etc/pam.d/common-auth"
+      ],
       "remediation": "Ensure login failure messages do not reveal whether username or password was wrong."
     },
     {
@@ -199,7 +293,9 @@
       "name": "Identifier Management",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["awk -F: '{print $3}' /etc/passwd | sort | uniq -d"],
+      "os_checks": [
+        "awk -F: '{print $3}' /etc/passwd | sort | uniq -d"
+      ],
       "remediation": "Eliminate duplicate UIDs in /etc/passwd. Never reuse a UID after deleting an account."
     },
     {
@@ -207,8 +303,13 @@
       "family": "IA",
       "name": "Cryptographic Module Authentication",
       "status": "full",
-      "openclaw_settings": ["gateway.tls"],
-      "os_checks": ["grep Protocol /etc/ssh/sshd_config", "grep Ciphers /etc/ssh/sshd_config"],
+      "openclaw_settings": [
+        "gateway.tls"
+      ],
+      "os_checks": [
+        "grep Protocol /etc/ssh/sshd_config",
+        "grep Ciphers /etc/ssh/sshd_config"
+      ],
       "remediation": "Disable SSHv1 and weak ciphers (3DES, RC4/arcfour, CBC-mode) in sshd_config. Set gateway TLS minVersion to TLSv1.2 or higher."
     },
     {
@@ -216,8 +317,13 @@
       "family": "IA",
       "name": "Identification and Authentication (Non-Org Users)",
       "status": "full",
-      "openclaw_settings": ["auth.mode", "auth.providers"],
-      "os_checks": ["grep -o auth.mode/providers in openclaw.json"],
+      "openclaw_settings": [
+        "auth.mode",
+        "auth.providers"
+      ],
+      "os_checks": [
+        "grep -o auth.mode/providers in openclaw.json"
+      ],
       "remediation": "Set an explicit auth.mode and register auth.providers. Disable anonymous access so external channel users (Discord/Telegram/etc.) are identified before gateway trust."
     },
     {
@@ -225,8 +331,12 @@
       "family": "IA",
       "name": "Re-authentication",
       "status": "full",
-      "openclaw_settings": ["mcp.sessionIdleTtlMs"],
-      "os_checks": ["grep sessionIdleTtlMs in openclaw.json"],
+      "openclaw_settings": [
+        "mcp.sessionIdleTtlMs"
+      ],
+      "os_checks": [
+        "grep sessionIdleTtlMs in openclaw.json"
+      ],
       "remediation": "Set mcp.sessionIdleTtlMs to a finite, reasonable value (e.g. 24h or less) so idle sessions require re-authentication."
     },
     {
@@ -234,8 +344,14 @@
       "family": "SC",
       "name": "Transmission Confidentiality and Integrity",
       "status": "partial",
-      "openclaw_settings": ["gateway.tls", "gateway.remote.url"],
-      "os_checks": ["ss -tlnp", "openssl s_client -connect localhost:18790"],
+      "openclaw_settings": [
+        "gateway.tls",
+        "gateway.remote.url"
+      ],
+      "os_checks": [
+        "ss -tlnp",
+        "openssl s_client -connect localhost:18790"
+      ],
       "remediation": "Enable TLS on gateway. Use Cloudflare Tunnel (TLS enforced) for all remote access."
     },
     {
@@ -244,8 +360,59 @@
       "name": "Protection of Information at Rest",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["stat ~/.openclaw/secrets/", "ls -la ~/.openclaw/"],
+      "os_checks": [
+        "stat ~/.openclaw/secrets/",
+        "ls -la ~/.openclaw/"
+      ],
       "remediation": "Secrets directory must be 700. All secret files must be 600. Owner must be service account only."
+    },
+    {
+      "id": "SC-2",
+      "family": "SC",
+      "name": "Application Partitioning",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "ps aux",
+        "readlink /proc/PID/ns/mnt"
+      ],
+      "remediation": "Run OpenClaw under a dedicated non-root service account. Consider container or namespace isolation."
+    },
+    {
+      "id": "SC-4",
+      "family": "SC",
+      "name": "Information in Shared Resources",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "find /tmp -name *openclaw*",
+        "ls /dev/shm"
+      ],
+      "remediation": "Configure periodic cleanup of /tmp session data. Review /dev/shm for sensitive residue."
+    },
+    {
+      "id": "SC-12",
+      "family": "SC",
+      "name": "Cryptographic Key Establishment and Management",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "stat ~/.openclaw/secrets/*.key",
+        "stat ~/.ssh/id_*"
+      ],
+      "remediation": "All key/credential files must be 600 or 400. SSH private keys must be 600."
+    },
+    {
+      "id": "SC-13",
+      "family": "SC",
+      "name": "Cryptographic Protection",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "openssl version",
+        "node --version"
+      ],
+      "remediation": "Use OpenSSL 1.1+ or 3.x for FIPS capability. Node.js 18+ enforces TLS 1.2+ by default."
     },
     {
       "id": "SI-2",
@@ -253,7 +420,10 @@
       "name": "Flaw Remediation",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["apt list --upgradable", "unattended-upgrades --dry-run"],
+      "os_checks": [
+        "apt list --upgradable",
+        "unattended-upgrades --dry-run"
+      ],
       "remediation": "Enable unattended-upgrades for security patches. Review and apply pending updates."
     },
     {
@@ -262,7 +432,10 @@
       "name": "Malicious Code Protection",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["which clamav", "systemctl status clamav-daemon"],
+      "os_checks": [
+        "which clamav",
+        "systemctl status clamav-daemon"
+      ],
       "remediation": "Install and configure ClamAV or equivalent. Schedule regular scans."
     },
     {
@@ -271,7 +444,10 @@
       "name": "Software, Firmware, and Information Integrity",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["apt-config dump | grep -i AllowUnauthenticated", "ls /etc/apt/trusted.gpg.d/"],
+      "os_checks": [
+        "apt-config dump | grep -i AllowUnauthenticated",
+        "ls /etc/apt/trusted.gpg.d/"
+      ],
       "remediation": "Ensure APT::Get::AllowUnauthenticated is unset or false. Verify apt repository GPG keys are configured under /etc/apt/trusted.gpg.d/."
     },
     {
@@ -280,7 +456,9 @@
       "name": "Memory Protection",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["cat /proc/sys/kernel/randomize_va_space"],
+      "os_checks": [
+        "cat /proc/sys/kernel/randomize_va_space"
+      ],
       "remediation": "Set kernel.randomize_va_space=2 for full ASLR: sudo sysctl -w kernel.randomize_va_space=2."
     },
     {
@@ -288,7 +466,9 @@
       "family": "SA",
       "name": "External System Services",
       "status": "partial",
-      "openclaw_settings": ["mcp.servers"],
+      "openclaw_settings": [
+        "mcp.servers"
+      ],
       "os_checks": [],
       "remediation": "Review each configured mcp.servers entry for a data-sharing agreement and supply-chain risk assessment. Remove servers that are no longer needed."
     },
@@ -298,7 +478,10 @@
       "name": "Unsupported System Components",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["cat /etc/os-release", "node --version"],
+      "os_checks": [
+        "cat /etc/os-release",
+        "node --version"
+      ],
       "remediation": "Upgrade Ubuntu and Node.js before their end-of-life dates. Track EOL schedules at https://endoflife.date/ubuntu and https://endoflife.date/nodejs."
     },
     {
@@ -306,7 +489,10 @@
       "family": "MP",
       "name": "Media Sanitization",
       "status": "partial",
-      "openclaw_settings": ["media.ttlHours", "media.maxSizeMb"],
+      "openclaw_settings": [
+        "media.ttlHours",
+        "media.maxSizeMb"
+      ],
       "os_checks": [],
       "remediation": "Set media.ttlHours to a positive retention window and media.maxSizeMb to bound stored media size in the OpenClaw config."
     },
@@ -316,7 +502,10 @@
       "name": "Component Authenticity",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["ls ~/.openclaw/skills", "ls /etc/apt/trusted.gpg.d/"],
+      "os_checks": [
+        "ls ~/.openclaw/skills",
+        "ls /etc/apt/trusted.gpg.d/"
+      ],
       "remediation": "Add source/author/origin metadata to installed skills. Verify APT package signing keys are present under /etc/apt/trusted.gpg.d/."
     },
     {
@@ -324,8 +513,12 @@
       "family": "AC",
       "name": "Information Flow Enforcement",
       "status": "full",
-      "openclaw_settings": ["network.allowedHosts"],
-      "os_checks": ["iptables -L"],
+      "openclaw_settings": [
+        "network.allowedHosts"
+      ],
+      "os_checks": [
+        "iptables -L"
+      ],
       "remediation": "Configure network.allowedHosts in openclaw.json to restrict outbound connections."
     },
     {
@@ -334,7 +527,10 @@
       "name": "Separation of Duties",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["whoami", "groups <user>"],
+      "os_checks": [
+        "whoami",
+        "groups <user>"
+      ],
       "remediation": "Run OpenClaw under a dedicated service account that is not a member of the sudo/admin group."
     },
     {
@@ -343,7 +539,10 @@
       "name": "Unsuccessful Logon Attempts",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep pam_faillock /etc/pam.d/common-auth", "cat /etc/security/faillock.conf"],
+      "os_checks": [
+        "grep pam_faillock /etc/pam.d/common-auth",
+        "cat /etc/security/faillock.conf"
+      ],
       "remediation": "Enable pam_faillock in /etc/pam.d/common-auth and set deny to 3 or more failed attempts before lockout."
     },
     {
@@ -352,7 +551,9 @@
       "name": "System Use Notification",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep ^Banner /etc/ssh/sshd_config"],
+      "os_checks": [
+        "grep ^Banner /etc/ssh/sshd_config"
+      ],
       "remediation": "Set a Banner directive in sshd_config pointing to a system-use notification file."
     },
     {
@@ -361,7 +562,9 @@
       "name": "Concurrent Session Control",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["grep maxlogins /etc/security/limits.conf"],
+      "os_checks": [
+        "grep maxlogins /etc/security/limits.conf"
+      ],
       "remediation": "Set a maxlogins limit in /etc/security/limits.conf to bound concurrent sessions per user."
     },
     {
@@ -370,7 +573,9 @@
       "name": "Device Lock",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["grep TMOUT /etc/profile /etc/profile.d/*"],
+      "os_checks": [
+        "grep TMOUT /etc/profile /etc/profile.d/*"
+      ],
       "remediation": "Set TMOUT in /etc/profile or /etc/profile.d/ to auto-lock idle shell sessions."
     },
     {
@@ -378,7 +583,9 @@
       "family": "AC",
       "name": "Session Termination",
       "status": "full",
-      "openclaw_settings": ["sessions.idleTimeoutMinutes"],
+      "openclaw_settings": [
+        "sessions.idleTimeoutMinutes"
+      ],
       "os_checks": [],
       "remediation": "Set sessions.idleTimeoutMinutes in openclaw.json so idle OpenClaw sessions terminate automatically."
     },
@@ -387,7 +594,9 @@
       "family": "AC",
       "name": "Permitted Actions Without Identification or Authentication",
       "status": "full",
-      "openclaw_settings": ["auth.enabled"],
+      "openclaw_settings": [
+        "auth.enabled"
+      ],
       "os_checks": [],
       "remediation": "Set auth.enabled to true in openclaw.json so gateway actions require identification/authentication."
     },
@@ -397,7 +606,10 @@
       "name": "Configuration Change Control",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["ls -la ~/.openclaw/.git", "ls ~/.sarge/snapshots/latest.json"],
+      "os_checks": [
+        "ls -la ~/.openclaw/.git",
+        "ls ~/.sarge/snapshots/latest.json"
+      ],
       "remediation": "Track ~/.openclaw under version control, or run drift/snapshot.sh regularly to detect unreviewed configuration changes."
     },
     {
@@ -406,7 +618,9 @@
       "name": "Access Restrictions for Change",
       "status": "full",
       "openclaw_settings": [],
-      "os_checks": ["stat -c %U ~/.openclaw/openclaw.json"],
+      "os_checks": [
+        "stat -c %U ~/.openclaw/openclaw.json"
+      ],
       "remediation": "Ensure OpenClaw config files are owned by the agent service account, not root."
     },
     {
@@ -414,8 +628,13 @@
       "family": "CM",
       "name": "System Component Inventory",
       "status": "full",
-      "openclaw_settings": ["mcp.servers", "plugins.entries"],
-      "os_checks": ["node --version"],
+      "openclaw_settings": [
+        "mcp.servers",
+        "plugins.entries"
+      ],
+      "os_checks": [
+        "node --version"
+      ],
       "remediation": "Maintain an approved component list and reconcile it against the reported Node.js version, MCP servers, and plugins."
     },
     {
@@ -424,7 +643,9 @@
       "name": "User-Installed Software",
       "status": "partial",
       "openclaw_settings": [],
-      "os_checks": ["npm list -g --depth=0"],
+      "os_checks": [
+        "npm list -g --depth=0"
+      ],
       "remediation": "Review globally-installed npm packages and remove any that are not approved for the host."
     }
   ]

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -122,6 +122,15 @@
       "remediation": "Add auditd watch rules for ~/.openclaw/secrets/ and OpenClaw config files."
     },
     {
+      "id": "CA-9",
+      "family": "CA",
+      "name": "Internal System Connections",
+      "status": "partial",
+      "openclaw_settings": ["mcp.servers"],
+      "os_checks": ["parse ~/.openclaw/openclaw.json mcp.servers"],
+      "remediation": "Document each MCP server connection in the system security plan / interconnection agreements. Remove any unused or unauthorized servers."
+    },
+    {
       "id": "CM-2",
       "family": "CM",
       "name": "Baseline Configuration",
@@ -147,6 +156,15 @@
       "openclaw_settings": ["plugins.enabled", "tools.enabled"],
       "os_checks": ["systemctl list-units --state=enabled", "apt list --installed"],
       "remediation": "Disable unused OpenClaw plugins and tools. Remove unnecessary OS packages."
+    },
+    {
+      "id": "CP-9",
+      "family": "CP",
+      "name": "System Backup",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["crontab -l | grep -i backup", "systemctl list-timers --all | grep -i backup"],
+      "remediation": "Configure a scheduled backup (cron or systemd timer) of ~/.openclaw config, secrets, and workspace state. Verify backups are recoverable."
     },
     {
       "id": "IA-2",
@@ -246,6 +264,60 @@
       "openclaw_settings": [],
       "os_checks": ["which clamav", "systemctl status clamav-daemon"],
       "remediation": "Install and configure ClamAV or equivalent. Schedule regular scans."
+    },
+    {
+      "id": "SI-7",
+      "family": "SI",
+      "name": "Software, Firmware, and Information Integrity",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["apt-config dump | grep -i AllowUnauthenticated", "ls /etc/apt/trusted.gpg.d/"],
+      "remediation": "Ensure APT::Get::AllowUnauthenticated is unset or false. Verify apt repository GPG keys are configured under /etc/apt/trusted.gpg.d/."
+    },
+    {
+      "id": "SI-16",
+      "family": "SI",
+      "name": "Memory Protection",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["cat /proc/sys/kernel/randomize_va_space"],
+      "remediation": "Set kernel.randomize_va_space=2 for full ASLR: sudo sysctl -w kernel.randomize_va_space=2."
+    },
+    {
+      "id": "SA-9",
+      "family": "SA",
+      "name": "External System Services",
+      "status": "partial",
+      "openclaw_settings": ["mcp.servers"],
+      "os_checks": [],
+      "remediation": "Review each configured mcp.servers entry for a data-sharing agreement and supply-chain risk assessment. Remove servers that are no longer needed."
+    },
+    {
+      "id": "SA-22",
+      "family": "SA",
+      "name": "Unsupported System Components",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["cat /etc/os-release", "node --version"],
+      "remediation": "Upgrade Ubuntu and Node.js before their end-of-life dates. Track EOL schedules at https://endoflife.date/ubuntu and https://endoflife.date/nodejs."
+    },
+    {
+      "id": "MP-6",
+      "family": "MP",
+      "name": "Media Sanitization",
+      "status": "partial",
+      "openclaw_settings": ["media.ttlHours", "media.maxSizeMb"],
+      "os_checks": [],
+      "remediation": "Set media.ttlHours to a positive retention window and media.maxSizeMb to bound stored media size in the OpenClaw config."
+    },
+    {
+      "id": "SR-11",
+      "family": "SR",
+      "name": "Component Authenticity",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["ls ~/.openclaw/skills", "ls /etc/apt/trusted.gpg.d/"],
+      "remediation": "Add source/author/origin metadata to installed skills. Verify APT package signing keys are present under /etc/apt/trusted.gpg.d/."
     }
   ]
 }

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -415,6 +415,45 @@
       "remediation": "Use OpenSSL 1.1+ or 3.x for FIPS capability. Node.js 18+ enforces TLS 1.2+ by default."
     },
     {
+      "id": "SC-15",
+      "family": "SC",
+      "name": "Collaborative Computing Devices",
+      "status": "full",
+      "openclaw_settings": [
+        "nodes.*.capabilities.camera",
+        "nodes.*.capabilities.microphone"
+      ],
+      "os_checks": [
+        "v4l2-ctl --list-devices",
+        "ls /dev/video*"
+      ],
+      "remediation": "Disable camera/microphone capabilities in openclaw.json unless required. Remove /dev/video* access for the agent user."
+    },
+    {
+      "id": "SC-23",
+      "family": "SC",
+      "name": "Session Authenticity",
+      "status": "full",
+      "openclaw_settings": [
+        "auth.enabled",
+        "gatewayToken"
+      ],
+      "os_checks": [],
+      "remediation": "Set auth.enabled: true and configure a strong gatewayToken in openclaw.json."
+    },
+    {
+      "id": "SC-39",
+      "family": "SC",
+      "name": "Process Isolation",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "cat /proc/PID/cgroup",
+        "readlink /proc/PID/ns/{pid,net,mnt}"
+      ],
+      "remediation": "Run OpenClaw in a container or systemd slice with resource limits. Use network and PID namespaces to isolate the agent."
+    },
+    {
       "id": "SI-2",
       "family": "SI",
       "name": "Flaw Remediation",

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -59,6 +59,42 @@
       "remediation": "Ensure audit records include timestamp, user, action, and outcome."
     },
     {
+      "id": "AU-4",
+      "family": "AU",
+      "name": "Audit Log Storage Capacity",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["df -P /var/log/audit", "df -P /var/log"],
+      "remediation": "Ensure the audit log partition retains at least 10% free space. Configure log rotation with adequate headroom or expand storage."
+    },
+    {
+      "id": "AU-5",
+      "family": "AU",
+      "name": "Response to Audit Processing Failures",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["grep disk_full_action /etc/audit/auditd.conf", "grep admin_space_left_action /etc/audit/auditd.conf"],
+      "remediation": "Set disk_full_action and admin_space_left_action in auditd.conf to something other than IGNORE (e.g. SYSLOG, EMAIL, HALT)."
+    },
+    {
+      "id": "AU-7",
+      "family": "AU",
+      "name": "Audit Record Reduction and Report Generation",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["which journalctl", "which ausearch", "grep -r '@' /etc/rsyslog.d/"],
+      "remediation": "Install auditd (provides ausearch) or configure rsyslog forwarding so audit records can be queried and aggregated."
+    },
+    {
+      "id": "AU-8",
+      "family": "AU",
+      "name": "Time Stamps",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["timedatectl show -p NTPSynchronized", "chronyc tracking"],
+      "remediation": "Enable NTP synchronization: sudo timedatectl set-ntp true."
+    },
+    {
       "id": "AU-9",
       "family": "AU",
       "name": "Protection of Audit Information",
@@ -66,6 +102,15 @@
       "openclaw_settings": [],
       "os_checks": ["ls -la /var/log/audit/", "stat /var/log/audit/audit.log"],
       "remediation": "Audit logs must be owned by root, mode 600. Restrict write access."
+    },
+    {
+      "id": "AU-11",
+      "family": "AU",
+      "name": "Audit Record Retention",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["grep rotate /etc/logrotate.d/auditd"],
+      "remediation": "Configure logrotate for audit logs with a 'rotate' count of at least 4 (weekly rotation) to meet minimum retention."
     },
     {
       "id": "AU-12",
@@ -129,6 +174,42 @@
       "openclaw_settings": [],
       "os_checks": ["grep pam_unix /etc/pam.d/common-auth"],
       "remediation": "Ensure login failure messages do not reveal whether username or password was wrong."
+    },
+    {
+      "id": "IA-4",
+      "family": "IA",
+      "name": "Identifier Management",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["awk -F: '{print $3}' /etc/passwd | sort | uniq -d"],
+      "remediation": "Eliminate duplicate UIDs in /etc/passwd. Never reuse a UID after deleting an account."
+    },
+    {
+      "id": "IA-7",
+      "family": "IA",
+      "name": "Cryptographic Module Authentication",
+      "status": "full",
+      "openclaw_settings": ["gateway.tls"],
+      "os_checks": ["grep Protocol /etc/ssh/sshd_config", "grep Ciphers /etc/ssh/sshd_config"],
+      "remediation": "Disable SSHv1 and weak ciphers (3DES, RC4/arcfour, CBC-mode) in sshd_config. Set gateway TLS minVersion to TLSv1.2 or higher."
+    },
+    {
+      "id": "IA-8",
+      "family": "IA",
+      "name": "Identification and Authentication (Non-Org Users)",
+      "status": "full",
+      "openclaw_settings": ["auth.mode", "auth.providers"],
+      "os_checks": ["grep -o auth.mode/providers in openclaw.json"],
+      "remediation": "Set an explicit auth.mode and register auth.providers. Disable anonymous access so external channel users (Discord/Telegram/etc.) are identified before gateway trust."
+    },
+    {
+      "id": "IA-11",
+      "family": "IA",
+      "name": "Re-authentication",
+      "status": "full",
+      "openclaw_settings": ["mcp.sessionIdleTtlMs"],
+      "os_checks": ["grep sessionIdleTtlMs in openclaw.json"],
+      "remediation": "Set mcp.sessionIdleTtlMs to a finite, reasonable value (e.g. 24h or less) so idle sessions require re-authentication."
     },
     {
       "id": "SC-8",

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -318,6 +318,114 @@
       "openclaw_settings": [],
       "os_checks": ["ls ~/.openclaw/skills", "ls /etc/apt/trusted.gpg.d/"],
       "remediation": "Add source/author/origin metadata to installed skills. Verify APT package signing keys are present under /etc/apt/trusted.gpg.d/."
+    },
+    {
+      "id": "AC-4",
+      "family": "AC",
+      "name": "Information Flow Enforcement",
+      "status": "full",
+      "openclaw_settings": ["network.allowedHosts"],
+      "os_checks": ["iptables -L"],
+      "remediation": "Configure network.allowedHosts in openclaw.json to restrict outbound connections."
+    },
+    {
+      "id": "AC-5",
+      "family": "AC",
+      "name": "Separation of Duties",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["whoami", "groups <user>"],
+      "remediation": "Run OpenClaw under a dedicated service account that is not a member of the sudo/admin group."
+    },
+    {
+      "id": "AC-7",
+      "family": "AC",
+      "name": "Unsuccessful Logon Attempts",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["grep pam_faillock /etc/pam.d/common-auth", "cat /etc/security/faillock.conf"],
+      "remediation": "Enable pam_faillock in /etc/pam.d/common-auth and set deny to 3 or more failed attempts before lockout."
+    },
+    {
+      "id": "AC-8",
+      "family": "AC",
+      "name": "System Use Notification",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["grep ^Banner /etc/ssh/sshd_config"],
+      "remediation": "Set a Banner directive in sshd_config pointing to a system-use notification file."
+    },
+    {
+      "id": "AC-10",
+      "family": "AC",
+      "name": "Concurrent Session Control",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["grep maxlogins /etc/security/limits.conf"],
+      "remediation": "Set a maxlogins limit in /etc/security/limits.conf to bound concurrent sessions per user."
+    },
+    {
+      "id": "AC-11",
+      "family": "AC",
+      "name": "Device Lock",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["grep TMOUT /etc/profile /etc/profile.d/*"],
+      "remediation": "Set TMOUT in /etc/profile or /etc/profile.d/ to auto-lock idle shell sessions."
+    },
+    {
+      "id": "AC-12",
+      "family": "AC",
+      "name": "Session Termination",
+      "status": "full",
+      "openclaw_settings": ["sessions.idleTimeoutMinutes"],
+      "os_checks": [],
+      "remediation": "Set sessions.idleTimeoutMinutes in openclaw.json so idle OpenClaw sessions terminate automatically."
+    },
+    {
+      "id": "AC-14",
+      "family": "AC",
+      "name": "Permitted Actions Without Identification or Authentication",
+      "status": "full",
+      "openclaw_settings": ["auth.enabled"],
+      "os_checks": [],
+      "remediation": "Set auth.enabled to true in openclaw.json so gateway actions require identification/authentication."
+    },
+    {
+      "id": "CM-3",
+      "family": "CM",
+      "name": "Configuration Change Control",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["ls -la ~/.openclaw/.git", "ls ~/.sarge/snapshots/latest.json"],
+      "remediation": "Track ~/.openclaw under version control, or run drift/snapshot.sh regularly to detect unreviewed configuration changes."
+    },
+    {
+      "id": "CM-5",
+      "family": "CM",
+      "name": "Access Restrictions for Change",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": ["stat -c %U ~/.openclaw/openclaw.json"],
+      "remediation": "Ensure OpenClaw config files are owned by the agent service account, not root."
+    },
+    {
+      "id": "CM-8",
+      "family": "CM",
+      "name": "System Component Inventory",
+      "status": "full",
+      "openclaw_settings": ["mcp.servers", "plugins.entries"],
+      "os_checks": ["node --version"],
+      "remediation": "Maintain an approved component list and reconcile it against the reported Node.js version, MCP servers, and plugins."
+    },
+    {
+      "id": "CM-11",
+      "family": "CM",
+      "name": "User-Installed Software",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": ["npm list -g --depth=0"],
+      "remediation": "Review globally-installed npm packages and remove any that are not approved for the host."
     }
   ]
 }

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -686,6 +686,19 @@
         "npm list -g --depth=0"
       ],
       "remediation": "Review globally-installed npm packages and remove any that are not approved for the host."
+    },
+    {
+      "id": "RA-5",
+      "family": "RA",
+      "name": "Vulnerability Monitoring and Scanning",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "trivy/grype/oscap/lynis/debsecan",
+        "npm audit",
+        "apt list --upgradable"
+      ],
+      "remediation": "Install a vulnerability scanner (trivy or grype recommended). Run npm audit on OpenClaw dependencies. Apply pending OS security patches."
     }
   ]
 }

--- a/docs/SARGE-REFERENCE.md
+++ b/docs/SARGE-REFERENCE.md
@@ -1,0 +1,1035 @@
+# Sarge — Deep Reference Document
+
+> **Version:** 0.7.0 | **Publisher:** Oscar Six Security LLC | **License:** Apache 2.0
+> **Focus Forward. We've Got Your Six.**
+
+This document is a comprehensive technical reference for the Sarge codebase. It is designed to let any developer or AI agent cold-start into the project without reading every file.
+
+---
+
+## Table of Contents
+
+1. [Mission & Threat Model](#mission--threat-model)
+2. [Architecture Overview](#architecture-overview)
+3. [Tech Stack](#tech-stack)
+4. [Platform Support Matrix](#platform-support-matrix)
+5. [File Map](#file-map)
+6. [CLI Commands & Entry Points](#cli-commands--entry-points)
+7. [Assessment Engine (Gap Analysis)](#assessment-engine-gap-analysis)
+8. [Check Categories & NIST 800-53 Control Mapping](#check-categories--nist-800-53-control-mapping)
+9. [Findings Catalog](#findings-catalog)
+10. [Report Generation](#report-generation)
+11. [Hardening Scripts](#hardening-scripts)
+12. [Drift Detection](#drift-detection)
+13. [Pre-Hardening Backup & Rollback](#pre-hardening-backup--rollback)
+14. [Platform Abstraction Layer](#platform-abstraction-layer)
+15. [Windows Assessment Engine](#windows-assessment-engine)
+16. [Policy Overlay (Windows Phase 1b)](#policy-overlay-windows-phase-1b)
+17. [Configuration & Baseline](#configuration--baseline)
+18. [OpenClaw Integration (Skill)](#openclaw-integration-skill)
+19. [Testing](#testing)
+20. [Deployment & Packaging](#deployment--packaging)
+21. [Exit Code Contract](#exit-code-contract)
+22. [Hard Rules & Conventions](#hard-rules--conventions)
+23. [Roadmap & Issue Tracker](#roadmap--issue-tracker)
+
+---
+
+## Mission & Threat Model
+
+Sarge is an **agent-safety control** for OpenClaw deployments, not a generic OS hardening kit.
+
+The primary use case: verify that a host running OpenClaw (or another AI agent) meets an 800-53 baseline **before** the agent is allowed to make autonomous changes. The risk isn't abstract "this laptop has CVE-X open" — it's "an agent with shell access is about to act on a system whose posture we haven't verified, and a wrong action against a weak baseline cascades into incident territory."
+
+**Two-phase safety net:**
+1. **Pre-flight (Sarge):** Assess the host against NIST 800-53 Rev 5. Surface gaps before the agent gets the keys.
+2. **Post-action recovery (rollback/restore):** When the agent makes the wrong change, the rollback path is the safety net. Drift detection feeds this — drift is the signal that recovery may be needed.
+
+**Check prioritization (Tier system from memory):**
+- **Tier 1 — Agent-safety controls:** Workspace ACLs, audit trail for agent actions, rollback capability, secrets directory permissions. These are the controls that directly contain agent risk.
+- **Tier 2 — Baseline hygiene:** Password policy, firewall, ClamAV, unattended-upgrades, SSH hardening. These form the surrounding baseline that makes Tier 1 controls meaningful. Weak workspace ACLs let one compromised tool exfiltrate secrets; missing audit means an agent's wrong action is invisible.
+
+---
+
+## Architecture Overview
+
+Sarge is a pure-shell (bash + PowerShell) project with zero runtime dependencies beyond the target OS's built-in tools. No Node.js, no Python (used only for optional JSON parsing in report generation), no external APIs.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Entry Points                          │
+│  assess.sh (Linux/macOS)    assess.ps1 (Windows)        │
+│  install.sh                 snapshot.sh / compare.sh     │
+└────────────┬────────────────────────┬───────────────────┘
+             │                        │
+    ┌────────▼────────┐      ┌────────▼────────┐
+    │ Platform Layer  │      │ Platform Layer  │
+    │ lib/platform.sh │      │ lib/platform.ps1│
+    │ lib/platforms/  │      │ lib/findings.ps1│
+    │   _dispatch.sh  │      │ lib/probes/     │
+    │   ubuntu.sh     │      │   windows-*.ps1 │
+    │   macos.sh      │      │ lib/policy-     │
+    └────────┬────────┘      │   overlay.ps1   │
+             │               └────────┬────────┘
+    ┌────────▼────────┐      ┌────────▼────────┐
+    │  Check Scripts  │      │  Check Scripts  │
+    │  checks/        │      │  checks/        │
+    │  check-ac.sh    │      │  check-ac.ps1   │
+    │  check-au.sh    │      │  check-au.ps1   │
+    │  check-cm.sh    │      │  check-cm.ps1   │
+    │  check-ia.sh    │      │  check-ia.ps1   │
+    │  check-sc.sh    │      │  check-sc.ps1   │
+    │  check-si.sh    │      │  check-si.ps1   │
+    └────────┬────────┘      └────────┬────────┘
+             │                        │
+    ┌────────▼────────┐      ┌────────▼────────┐
+    │ Report Engine   │      │ Report Engine   │
+    │ report/         │      │ report/         │
+    │  report.sh      │      │  build-report   │
+    │                 │      │    .ps1         │
+    └─────────────────┘      └─────────────────┘
+```
+
+**Key architectural decisions:**
+- Platform-specific data acquisition is separated from 800-53 control logic. Check scripts contain assertions and verdicts; platform files contain probes.
+- The dispatcher pattern (`platform <probe>`) allows check scripts to be platform-agnostic. Missing probes return exit 127 (not implemented), which routes to a `skipx` with a platform-aware rationale.
+- All state lives under `~/.sarge/` (reports, snapshots, runs, state counters).
+- Per-run folders (`~/.sarge/runs/<run-id>/`) are self-contained: each run gets its own report.md, report.json, findings.json, and optionally drift-snapshot.json, drift-report.json, and backup/.
+
+---
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Assessment engine (Linux/macOS) | Bash (POSIX-compatible where possible) |
+| Assessment engine (Windows) | PowerShell 5.1+ / PowerShell 7+ |
+| Platform probes (Linux) | GNU coreutils, systemctl, apt, auditctl, ss, ufw |
+| Platform probes (macOS) | BSD coreutils, dscl, launchctl, socketfilterfw, lsof |
+| Platform probes (Windows) | CIM cmdlets, dsregcmd, gpresult, Get-MpComputerStatus, Get-AppLockerPolicy |
+| Report generation | Bash (jq preferred, python3 fallback, grep last-resort) |
+| Report generation (Windows) | PowerShell (ConvertTo-Json) |
+| Integrity verification | sha256sum (GNU) / shasum (BSD) |
+| Drift comparison | python3 one-liner for JSON field extraction |
+| CI | GitHub Actions (Pester on windows-latest) |
+| Test framework (Windows) | Pester 5.5+ |
+| Test framework (Linux/macOS) | Shell integration tests (bash scripts) |
+| Container image | Ubuntu 26.04 + Node 22 (Dockerfile.hardened) |
+
+---
+
+## Platform Support Matrix
+
+| Platform | Gap Analysis | Hardening | Drift Detection | Backup/Rollback |
+|----------|-------------|-----------|----------------|-----------------|
+| Ubuntu 22.04 LTS | Full (47 controls) | Full (6 modules) | Full | Full (#29) |
+| Ubuntu 24.04 LTS | Full (47 controls) | Full (6 modules) | Full | Full (#29) |
+| macOS (any version) | Full (platform-aware skips) | Partial (3 modules) | Full | Spec'd, untested (#30) |
+| Windows (any) | Full (Phase 1a + 1b) | Blocked on backup (#28) | N/A | Spec'd (#28) |
+
+---
+
+## File Map
+
+### Root
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Project documentation, quickstart, control coverage tables |
+| `SKILL.md` | OpenClaw skill definition for ClawhHub |
+| `CHECKSUMS.sha256` | Integrity verification hashes for all scripts |
+| `CHANGELOG.md` | Version history |
+| `CONTRIBUTING.md` | Contribution guidelines |
+| `CODE_OF_CONDUCT.md` | Community standards |
+| `SECURITY.md` | Vulnerability disclosure policy |
+| `LICENSE` | Apache 2.0 |
+| `Dockerfile.hardened` | QA test environment (Ubuntu 26.04 + Node 22) |
+| `Dockerfile.qa` | Additional QA image |
+
+### `assessment/` — Gap Analysis Engine
+
+| File | Purpose |
+|------|---------|
+| `assess.sh` | **Main entry point** (Linux/macOS). Sources platform libs, runs all check-*.sh, generates reports. |
+| `assess.ps1` | **Main entry point** (Windows). Loads probes, runs check-*.ps1, builds report. |
+| `findings-catalog.json` | Per-finding rationale catalog. Maps check_id → family, what, expected, why, fix. |
+| `checks/check-ac.sh` | Access Control checks (AC-2, AC-3, AC-6, AC-17) |
+| `checks/check-au.sh` | Audit & Accountability checks (AU-2, AU-3, AU-4, AU-5, AU-7, AU-8, AU-9, AU-11, AU-12) |
+| `checks/check-cm.sh` | Configuration Management checks (CM-2, CM-6, CM-7) |
+| `checks/check-ia.sh` | Identification & Authentication checks (IA-2, IA-5) |
+| `checks/check-sc.sh` | System & Communications Protection checks (SC-8, SC-28) |
+| `checks/check-si.sh` | System & Information Integrity checks (SI-2, SI-3, SI-7) |
+| `checks/check-ac.ps1` | Windows AC checks |
+| `checks/check-au.ps1` | Windows AU checks |
+| `checks/check-cm.ps1` | Windows CM checks |
+| `checks/check-ia.ps1` | Windows IA checks |
+| `checks/check-sc.ps1` | Windows SC checks |
+| `checks/check-si.ps1` | Windows SI checks |
+| `checks/check-policy.ps1` | Windows policy overlay checks (Phase 1b) |
+| `probes/detect-context.ps1` | Windows enterprise context detection probe |
+| `report/report.sh` | Markdown + JSON report generator (Linux/macOS) |
+| `report/build-report.ps1` | Report builder (Windows) |
+
+### `lib/` — Platform Abstraction & Shared Libraries
+
+| File | Purpose |
+|------|---------|
+| `platform.sh` | OS detection: exports `SARGE_OS`, `SARGE_OS_VERSION`, `SARGE_OS_DESCRIPTION`. Gates: `sarge_require_supported_os`, `sarge_require_os`. |
+| `platform.ps1` | Windows context detection: `Get-SargeWindowsContext` → enterprise context JSON (dsregcmd, GPO, AppLocker, WDAC, Defender, edition, OpenClaw path). |
+| `findings.ps1` | Windows finding emission: `Add-SargeFinding`, `Get-SargeContext`, `Invoke-SargeCheck`. Verdict vocabulary: PASS, FAIL, WARN, SKIP-CONTEXT-DEFERRED, ENFORCED-EXTERNALLY, UNTESTED. |
+| `policy-overlay.ps1` | `Apply-PolicyOverlay` — re-verdicts Phase 1a FAIL/WARN → ENFORCED-EXTERNALLY when managed policy enforces the control. |
+| `platforms/_dispatch.sh` | Cross-platform dispatcher: `platform <probe> [args...]` calls `${SARGE_OS}_<probe>`. `platform_supports <probe>` checks existence. Shared drift field helpers. |
+| `platforms/ubuntu.sh` | Ubuntu probe implementations (35+ functions). |
+| `platforms/macos.sh` | macOS probe implementations (20+ functions). Intentionally missing probes for auditd, pwquality, faillock, package management → routes to skipx. |
+| `probes/windows-ac.ps1` | Windows Access Control probes |
+| `probes/windows-au.ps1` | Windows Audit probes |
+| `probes/windows-cm.ps1` | Windows Configuration Management probes |
+| `probes/windows-ia.ps1` | Windows Identification & Authentication probes |
+| `probes/windows-sc.ps1` | Windows System & Communications Protection probes |
+| `probes/windows-si.ps1` | Windows System & Information Integrity probes |
+| `probes/windows-policy.ps1` | Windows policy probe (Phase 1b): `Get-SargeHostPolicyMode`, `Get-SargeMdmPolicyInventory`, `Get-SargeAdGpoData`, `Get-SargeGpresultData` |
+
+### `scripts/` — Hardening Modules
+
+| File | Platform | Sudo? | NIST Controls |
+|------|----------|-------|---------------|
+| `install.sh` | Ubuntu, macOS | Yes | All — orchestrator |
+| `harden-permissions.sh` | Ubuntu, macOS | **No** (runs as invoking user) | AC-3, SC-28 |
+| `harden-pam.sh` | Ubuntu only | Yes | IA-2, IA-5 |
+| `harden-auditd.sh` | Ubuntu only | Yes | AU-2, AU-9, AU-12 |
+| `harden-fail2ban.sh` | Ubuntu only | Yes | SI-3, AC-17 |
+| `harden-ufw.sh` | Ubuntu only | Yes | AC-17 |
+| `harden-systemd.sh` | Ubuntu only | Yes | CM-7 |
+| `harden-firewall-macos.sh` | macOS only | Yes | AC-17 |
+| `harden-ssh-macos.sh` | macOS only | Yes | CM-7 |
+| `backup-ubuntu.sh` | Ubuntu only | Mixed | Pre-hardening backup |
+| `backup-macos.sh` | macOS only | Yes | Pre-hardening backup |
+| `backup-windows.ps1` | Windows only | Yes | Pre-hardening backup |
+| `rollback-ubuntu.sh` | Ubuntu only | Mixed | Rollback |
+| `rollback-macos.sh` | macOS only | Yes | Rollback |
+| `rollback-windows.ps1` | Windows only | Yes | Rollback |
+
+### `drift/` — Drift Detection
+
+| File | Purpose |
+|------|---------|
+| `snapshot.sh` | Capture baseline snapshot → `~/.sarge/snapshots/snapshot-<ts>.json` + `latest.json` symlink |
+| `compare.sh` | Compare current state vs latest snapshot. Exit 0 = no drift, exit 2 = drift detected. |
+| `drift-cron.sh` | Cron wrapper for compare.sh. Logs to `~/.sarge/drift.log`, notifies via OpenClaw on drift. |
+
+### `baseline/` — Reference Configurations
+
+| File | Purpose |
+|------|---------|
+| `controls.json` | Machine-readable NIST 800-53 control mapping (23 controls, per-control OpenClaw settings + OS checks + remediation) |
+| `controls.md` | Human-readable control mapping (same content, Markdown format) |
+| `openclaw.json.baseline` | Hardened OpenClaw configuration baseline with inline 800-53 control annotations |
+
+### `tests/` — Test Suites
+
+| File | Purpose |
+|------|---------|
+| `integration/drift-detection.sh` | Snapshot → compare → verify pipeline |
+| `integration/report-validation.sh` | Runs assessment, validates JSON/MD output structure |
+| `integration/hardening-roundtrip.sh` | Assess → harden UFW → reassess → verify fix (needs NET_ADMIN) |
+| `integration/host-only-mode.sh` | Validates --host-only excludes agent findings |
+| `integration/backup-ubuntu-smoke.sh` | Ubuntu backup script smoke test |
+| `integration/backup-macos-smoke.sh` | macOS backup script smoke test (dry-run on Linux) |
+| `integration/catalog-platform-field.sh` | Validates per-platform fields in findings-catalog.json |
+| `Pester/windows-*.Tests.ps1` | Pester unit tests for all 6 Windows control families + policy + backup (mocked cmdlets) |
+
+### `docs/` — Documentation
+
+| File | Purpose |
+|------|---------|
+| `quickstart.md` | Getting started guide |
+| `accepted-risks.md` | Documented risk acceptances |
+| `sarge-agent.md` | Agent integration documentation |
+| `SARGE-REFERENCE.md` | This document |
+
+---
+
+## CLI Commands & Entry Points
+
+### Gap Analysis
+
+```bash
+# Linux/macOS — full agent-host mode (default)
+./assessment/assess.sh
+
+# Linux/macOS — host-only mode (no agent-runtime checks)
+./assessment/assess.sh --host-only
+
+# Windows
+pwsh assessment/assess.ps1
+pwsh assessment/assess.ps1 --host-only
+pwsh assessment/assess.ps1 --inspect-policy    # Phase 1b: probe managed policy
+pwsh assessment/assess.ps1 --checks-only       # Skip detection, reuse existing context
+pwsh assessment/assess.ps1 --report-only       # Rebuild report from last findings JSON
+```
+
+### Hardening
+
+```bash
+# Interactive installer (prompts per module)
+sudo ./scripts/install.sh
+
+# Individual modules
+bash scripts/harden-permissions.sh       # NO sudo (uses $HOME)
+sudo bash scripts/harden-pam.sh          # Ubuntu only
+sudo bash scripts/harden-auditd.sh       # Ubuntu only
+sudo bash scripts/harden-fail2ban.sh     # Ubuntu only
+sudo bash scripts/harden-ufw.sh          # Ubuntu only
+sudo bash scripts/harden-systemd.sh      # Ubuntu only
+sudo bash scripts/harden-firewall-macos.sh  # macOS only
+sudo bash scripts/harden-ssh-macos.sh       # macOS only
+```
+
+### Drift Detection
+
+```bash
+# Capture baseline
+./drift/snapshot.sh
+
+# Compare against baseline
+./drift/compare.sh
+
+# Cron-friendly wrapper (logs + notifies)
+./drift/drift-cron.sh
+
+# Suggested cron entry:
+# 0 6 * * * /path/to/sarge/drift/drift-cron.sh >> /var/log/sarge-drift.log 2>&1
+```
+
+### Backup & Rollback
+
+```bash
+# Ubuntu
+bash scripts/backup-ubuntu.sh --run-id "$SARGE_RUN_ID"
+bash scripts/backup-ubuntu.sh --unattended --run-id "$SARGE_RUN_ID"
+bash scripts/rollback-ubuntu.sh                  # latest run
+bash scripts/rollback-ubuntu.sh --run-id <id>     # specific run
+
+# macOS
+bash scripts/backup-macos.sh --run-id "$SARGE_RUN_ID"
+bash scripts/rollback-macos.sh --latest
+
+# Windows
+pwsh scripts/backup-windows.ps1
+pwsh scripts/rollback-windows.ps1 -BackupDir "$env:USERPROFILE\.sarge\runs\<id>\backup"
+```
+
+---
+
+## Assessment Engine (Gap Analysis)
+
+### Linux/macOS (`assess.sh`)
+
+**Flow:**
+1. Source `lib/platform.sh` — detect OS, version, validate support matrix
+2. Source `lib/platforms/_dispatch.sh` — load platform-specific probes
+3. Initialize state: report dir (`~/.sarge/reports/`), state dir (`~/.sarge/state/`), per-run dir (`~/.sarge/runs/<run-id>/`)
+4. Initialize counters: `PASS=0; WARN=0; FAIL=0; SKIP=0`
+5. Export verdict helper functions: `pass`, `warn`, `fail`, `skip` (legacy, no check_id) and `passx`, `warnx`, `failx`, `skipx` (structured, with check_id)
+6. Set scan mode: `agent-host` (default) or `host-only` (via `--host-only`)
+7. Source each `checks/check-*.sh` — they call verdict helpers which accumulate results in `RESULTS` array
+8. Pass accumulated results to `report/report.sh` for Markdown + JSON generation
+
+**Result format (internal):** Each result is a pipe-delimited string: `STATUS|check_id|description`
+- Legacy helpers emit: `STATUS||description` (empty check_id)
+- Structured helpers emit: `STATUS|check_id|description`
+
+**Key functions in assess.sh:**
+- `log()` — prefixed output: `[SARGE] message`
+- `pass(desc)` / `warn(desc)` / `fail(desc)` / `skip(desc)` — legacy verdict helpers
+- `passx(id, desc)` / `warnx(id, desc)` / `failx(id, desc)` / `skipx(id, desc)` — structured verdict helpers with catalog-joinable check_id
+
+**Environment variables:**
+- `SARGE_HOST_ONLY=1` — host-only mode (also set via `--host-only`)
+- `SARGE_REPORT_DIR` — override report output directory
+- `SARGE_STATE_DIR` — override state directory
+- `SARGE_RUN_ID` — override run identifier
+- `SARGE_RUN_ROOT` — override per-run directory
+- `SARGE_VERBOSE=1` — show skip messages from `sarge_require_os`
+
+### Windows (`assess.ps1`)
+
+**Flow:**
+1. Dot-source `lib/platform.ps1`, `lib/findings.ps1`, `lib/policy-overlay.ps1`, `report/build-report.ps1`
+2. Dot-source all 6 family probes from `lib/probes/windows-*.ps1`
+3. Run detection probe (`probes/detect-context.ps1`) → writes `windows-context.json`
+4. If `--inspect-policy`: run policy probe → populate policy inventory
+5. If `--inspect-policy`: run `checks/check-policy.ps1` first
+6. Source each `checks/check-*.ps1` — they call `Add-SargeFinding` / `Invoke-SargeCheck`
+7. If `--inspect-policy`: apply `Apply-PolicyOverlay` to mutate FAIL/WARN → ENFORCED-EXTERNALLY
+8. Call `Build-SargeReport` → generates Markdown + JSON + findings.json
+
+**Key functions:**
+- `Add-SargeFinding -Id -Family -ControlId -Verdict -Message [-Recommendation]` — emit one finding
+- `Invoke-SargeCheck -Id -Family -ControlId -Check { ... }` — run a check with error capture (throws → UNTESTED)
+- `Get-SargeContext` — load previously-written windows-context.json
+- `Get-SargeWindowsContext` — detect enterprise context (dsregcmd, CIM, AppLocker, WDAC, Defender)
+
+**Verdict vocabulary (Windows):**
+- `PASS` — meets baseline
+- `FAIL` — violates baseline
+- `WARN` — suspicious / review
+- `SKIP-CONTEXT-DEFERRED` — not evaluable locally
+- `ENFORCED-EXTERNALLY` — managed policy (MDM/GPO) enforces the control
+- `UNTESTED` — probe ambiguous / errored
+
+---
+
+## Check Categories & NIST 800-53 Control Mapping
+
+### AC — Access Control (8 checks on Linux/macOS)
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `AC-2-empty-password` | AC-2 | Accounts with empty password fields |
+| `AC-2-uid-zero` | AC-2 | Non-root accounts with UID 0 |
+| `AC-3-openclaw-dir-perm` | AC-3 | `~/.openclaw` directory is 700 (agent-scoped) |
+| `AC-3-secrets-dir-perm` | AC-3 | `~/.openclaw/secrets` directory is 700 (agent-scoped) |
+| `AC-3-secret-file-perm` | AC-3 | Individual secret files are 600 (agent-scoped) |
+| `AC-6-passwordless-sudo` | AC-6 | NOPASSWD sudo for current user |
+| `AC-6-user-in-sudo-group` | AC-6 | Current user in sudo/admin group |
+| `AC-17-ufw-inactive` | AC-17 | Host firewall active |
+| `AC-17-ufw-not-installed` | AC-17 | Firewall command available |
+| `AC-17-external-ports` | AC-17 | Externally-listening TCP ports |
+
+### AU — Audit & Accountability (13 checks on Linux/macOS)
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `AU-2-auditd-not-running` | AU-2 | Audit daemon running |
+| `AU-2-journald-inactive` | AU-2 | System logger (journald) active |
+| `AU-2-journal-not-persisted` | AU-2 | Journal logs persisted to disk |
+| `AU-4-log-storage` | AU-4 | Audit log partition has adequate free space (>10%) |
+| `AU-5-audit-failure-response` | AU-5 | auditd disk_full_action / admin_space_left_action not IGNORE |
+| `AU-7-log-tooling` | AU-7 | Log query/aggregation tooling available (journalctl, ausearch, syslog forwarding) |
+| `AU-8-time-sync` | AU-8 | System clock synchronized via NTP |
+| `AU-9-audit-log-bad-owner` | AU-9 | audit.log owned by root |
+| `AU-9-audit-log-perm` | AU-9 | audit.log permissions are 600 |
+| `AU-9-audit-log-missing` | AU-9 | audit.log exists when daemon is running |
+| `AU-11-log-retention` | AU-11 | logrotate retention for audit logs (>= 4 cycles) |
+| `AU-12-no-openclaw-rules` | AU-12 | Audit rules cover OpenClaw secrets (agent-scoped) |
+| `AU-12-no-auth-rules` | AU-12 | Audit rules cover /etc/passwd, shadow, sudoers |
+
+### CM — Configuration Management (10 checks on Linux/macOS)
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `CM-2-no-baseline` | CM-2 | Sarge baseline file exists |
+| `CM-6-unattended-not-installed` | CM-6 | unattended-upgrades installed |
+| `CM-6-unattended-not-configured` | CM-6 | unattended-upgrades configured |
+| `CM-6-pending-updates-low` | CM-6 | 1-5 pending package updates |
+| `CM-6-pending-updates-high` | CM-6 | >5 pending package updates |
+| `CM-7-risky-service-running` | CM-7 | Deny-listed service running |
+| `CM-7-risky-service-enabled` | CM-7 | Deny-listed service enabled |
+| `CM-7-ssh-permit-root` | CM-7 | SSH PermitRootLogin disabled |
+| `CM-7-ssh-password-auth` | CM-7 | SSH PasswordAuthentication disabled |
+
+### IA — Identification & Authentication (10 checks on Linux/macOS)
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `IA-5-pass-max-days` | IA-5 | PASS_MAX_DAYS ≤ 90 |
+| `IA-5-pass-min-days` | IA-5 | PASS_MIN_DAYS ≥ 1 |
+| `IA-5-pass-warn-age` | IA-5 | PASS_WARN_AGE ≥ 7 |
+| `IA-5-pwquality-minlen` | IA-5 | pwquality minlen ≥ 12 |
+| `IA-5-pwquality-credit` | IA-5 | pwquality dcredit/ucredit/ocredit/lcredit set |
+| `IA-5-pwquality-missing` | IA-5 | pwquality.conf exists |
+| `IA-2-faillock-not-configured` | IA-2 | pam_faillock in PAM stack |
+| `IA-2-faillock-deny` | IA-2 | faillock deny ≤ 5 |
+| `IA-2-faillock-unlock-time` | IA-2 | faillock unlock_time ≥ 1800s |
+| `IA-2-faillock-conf-missing` | IA-2 | faillock.conf exists |
+| `IA-2-tmout-unset` | IA-2 | TMOUT session timeout configured |
+
+### SC — System & Communications Protection (6 checks, partial)
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `SC-8-cloudflared-not-detected` | SC-8 | Gateway TLS via cloudflared or direct (agent-scoped) |
+| `SC-28-config-perm` | SC-28 | config.json permissions 600/400 (agent-scoped) |
+| `SC-28-config-owner` | SC-28 | config.json owned by service user (agent-scoped) |
+| `SC-28-world-readable-secrets` | SC-28 | No world-readable files in ~/.openclaw (agent-scoped) |
+
+### SI — System & Information Integrity (5 checks, partial)
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `SI-2-security-updates-low` | SI-2 | 1-3 security updates pending |
+| `SI-2-security-updates-high` | SI-2 | >3 security updates pending |
+| `SI-3-clamav-not-installed` | SI-3 | ClamAV installed |
+| `SI-3-clamav-daemon-stopped` | SI-3 | ClamAV daemon running |
+| `SI-3-freshclam-stopped` | SI-3 | freshclam (signature updater) running |
+| `SI-3-fail2ban-not-running` | SI-3 | fail2ban running with jails |
+| `SI-7-checksum-mismatch` | SI-7 | Sarge script checksums verified |
+
+### Windows-Specific Checks (WIN- prefix)
+
+The Windows assessment covers all 6 families with 30+ checks. Key additions beyond the Linux/macOS set:
+
+| Check ID | Control | What it checks |
+|----------|---------|---------------|
+| `WIN-AC-3-workspace-acl` | AC-3 | OpenClaw workspace ACL restricted |
+| `WIN-AC-6-admin-group` | AC-6 | Local Administrators group membership |
+| `WIN-AC-7-lockout-threshold` | AC-7 | Account lockout threshold 1-10 |
+| `WIN-AC-8-legal-banner` | AC-8 | Logon banner text set |
+| `WIN-AC-11-idle-lock` | AC-11 | Screen saver timeout + re-auth |
+| `WIN-AC-12-session-termination` | AC-12 | SMB autodisconnect ≤ 15 min |
+| `WIN-AC-17-rdp-posture` | AC-17 | RDP NLA + encryption + security layer |
+| `WIN-AU-2-audit-policy` | AU-2 | Required audit categories enabled |
+| `WIN-AU-3-sysmon-config` | AU-3 | Sysmon configuration present |
+| `WIN-AU-4-log-retention` | AU-4 | Event log channel sizes ≥ 64 MB |
+| `WIN-AU-6-event-forwarding` | AU-6 | WEF SubscriptionManager configured |
+| `WIN-AU-8-time-config` | AU-8 | W32Time sync mode valid |
+| `WIN-AU-9-security-log-acl` | AU-9 | Security.evtx ACL restricted |
+| `WIN-CM-2-baseline-drift` | CM-2 | Config drift vs stored baseline |
+| `WIN-CM-6-smbv1` | CM-6 | SMBv1 disabled |
+| `WIN-CM-6-legacy-services` | CM-6 | Legacy services stopped |
+| `WIN-CM-7-unnecessary-services` | CM-7 | CIS L1 services disabled |
+| `WIN-CM-8-software-inventory` | CM-8 | Software inventory captured |
+| `WIN-CM-11-user-installed-software` | CM-11 | Per-user installs governed |
+| `WIN-IA-2-account-types` | IA-2/AC-2 | MSA accounts flagged |
+| `WIN-IA-3-device-id` | IA-3 | TPM + Secure Boot present |
+| `WIN-IA-5-password-policy` | IA-5 | Local password policy baselines |
+| `WIN-IA-5-complexity` | IA-5 | Password complexity + no reversible encryption |
+| `WIN-IA-11-reauth` | IA-11 | Inactivity timeout ≤ 900s |
+| `WIN-IA-12-windows-hello` | IA-12 | Windows Hello credentials present |
+| `WIN-SC-2-uac` | SC-2 | UAC enabled with consent prompt |
+| `WIN-SC-7-firewall-profiles` | SC-7 | All 3 firewall profiles enabled |
+| `WIN-SC-7-listening-ports` | SC-7 | 0.0.0.0/:: listeners reviewed |
+| `WIN-SC-8-smb-signing` | SC-8 | SMB signing required |
+| `WIN-SC-12-key-mgmt` | SC-12 | LSA Protection + Credential Guard |
+| `WIN-SC-13-bitlocker` | SC-13 | BitLocker on OS volume |
+| `WIN-SC-23-ldap-ntlm` | SC-23 | LDAP signing + NTLM restriction |
+| `WIN-SC-28-bitlocker-policy` | SC-28 | BitLocker encryption method + escrow |
+| `WIN-SI-2-pending-updates` | SI-2 | Windows Update pending |
+| `WIN-SI-3-defender-realtime` | SI-3 | Defender real-time + AV enabled |
+| `WIN-SI-3-tamper-protection` | SI-3 | Defender tamper protection |
+| `WIN-SI-3-asr-rules` | SI-3 | ASR rules configured |
+| `WIN-SI-4-sysmon` | SI-4 | Sysmon installed |
+| `WIN-SI-5-update-reporting` | SI-5 | WSUS status server or Defender sample submission |
+| `WIN-SI-7-wdac-policy` | SI-7 | WDAC enforced |
+| `WIN-SI-8-spam-protection` | SI-8 | Mail role detection (N/A for most hosts) |
+| `WIN-SI-16-memory-protection` | SI-16 | DEP, ASLR, CFG, image signing |
+| `WIN-POL-1` | CM-2 | AAD-joined but no MDM enrollment |
+| `WIN-POL-2` | CM-6 | Policy inventory captured (informational) |
+
+### Agent-Scoped vs Host-Scoped
+
+Checks with `scope: "agent"` in findings-catalog.json are excluded in `--host-only` mode:
+- `AC-3-openclaw-dir-perm`, `AC-3-secrets-dir-perm`, `AC-3-secret-file-perm`
+- `AU-12-no-openclaw-rules`
+- `SC-8-cloudflared-not-detected`, `SC-28-config-perm`, `SC-28-config-owner`, `SC-28-world-readable-secrets`
+- `WIN-AC-3-workspace-acl`
+
+---
+
+## Findings Catalog
+
+`assessment/findings-catalog.json` is the central rationale database. Each entry is keyed by `check_id` and contains:
+
+```json
+{
+  "check_id": {
+    "family": "AC-3 — Access Enforcement",
+    "what": "Short description of the observed condition",
+    "expected": "What the value/state should be",
+    "why": "2-3 sentences explaining the security risk + NIST reference",
+    "fix": "Runnable command or one-line action",
+    "scope": "host | agent"
+  }
+}
+```
+
+**Per-platform fields:** `expected`, `why`, and `fix` can be either a string or a per-platform map:
+```json
+{
+  "fix": {
+    "default": "sudo ufw enable",
+    "macos": "sudo socketfilterfw --setglobalstate on"
+  }
+}
+```
+Report generation resolves via `$SARGE_OS` with fallback to `default`.
+
+**Naming convention:** `<NIST-FAMILY>-<CONTROL-NUMBER>-<short-slug>`. Family + control are uppercase (e.g. AC-3); slug is lowercase-kebab. Windows-specific IDs use the `WIN-` prefix. IDs are stable — never rename without a migration note.
+
+**Coverage rule:** Every `failx` and `warnx` callsite in check scripts MUST have a corresponding catalog entry. PASS and SKIP do not need entries.
+
+---
+
+## Report Generation
+
+### Linux/macOS (`report/report.sh`)
+
+**Inputs:** Pass/warn/fail/skip counts, pipe-delimited results array, output path, catalog path, mode.
+
+**Outputs:**
+- `<output>.md` — Markdown report with summary table, delta vs previous run, per-finding detail blocks
+- `<output>.json` — Machine-readable report (sarge_version, assessment_date, host, os, mode, summary, deltas, results)
+- `<run-root>/report.md` — Copy in per-run folder
+- `<run-root>/report.json` — Copy in per-run folder
+- `<run-root>/findings.json` — Flat findings array
+
+**Features:**
+- **Delta computation:** Finds previous report (prefers per-run layout, falls back to legacy `~/.sarge/reports/`), computes PASS/WARN/FAIL/SKIP deltas, renders Δ column in summary table
+- **Drift counter:** Increments when current FAIL > previous FAIL. Persisted in `~/.sarge/state/drift-count.txt`
+- **Install date tracking:** First-run date stored in `~/.sarge/state/installed-at.txt`
+- **Finding detail blocks:** For each FAIL/WARN, renders a block with: what, expected, why it matters, fix — all joined from findings-catalog.json
+- **JSON parser fallback chain:** jq (preferred) → python3 → grep regex
+
+### Windows (`report/build-report.ps1`)
+
+`Build-SargeReport` function accepts findings array, run ID, run root. Produces the same output shapes (report.md, report.json, findings.json). Uses PowerShell's `ConvertTo-Json` for JSON generation.
+
+---
+
+## Hardening Scripts
+
+All hardening scripts are:
+- **Idempotent** — safe to run multiple times
+- **Interactive** — each prompts `[y/N]` before making changes
+- **Non-destructive by default** — no changes without explicit confirmation
+- **Platform-gated** — wrong-platform scripts exit 0 silently via `sarge_require_os`
+
+### `harden-permissions.sh` (AC-3, SC-28)
+- Sets `~/.openclaw` → 700, `~/.openclaw/secrets` → 700, secret files → 600, config.json → 600
+- **Does NOT require sudo** — runs as invoking user. Resolves `$SUDO_USER` to find the correct home directory when invoked under sudo.
+- Function: `resolve_home_for_user($user)` — looks up home via `getent passwd` or `dscl`
+
+### `harden-pam.sh` (IA-2, IA-5) — Ubuntu only
+- Installs `libpam-pwquality`
+- Writes `/etc/security/pwquality.conf`: minlen=12, dcredit/ucredit/ocredit/lcredit=-1, maxrepeat=3, gecoscheck=1
+- Writes `/etc/security/faillock.conf`: deny=5, unlock_time=1800, fail_interval=900, silent, audit
+- Sets `/etc/login.defs`: PASS_MAX_DAYS=90, PASS_MIN_DAYS=1, PASS_WARN_AGE=14
+- Writes `/etc/profile.d/sarge-timeout.sh`: TMOUT=900, readonly
+
+### `harden-auditd.sh` (AU-2, AU-9, AU-12) — Ubuntu only
+- Installs `auditd` + `audispd-plugins`
+- Writes `/etc/audit/rules.d/sarge.rules` with watch rules for:
+  - `~/.openclaw/secrets` (rwxa, key: openclaw_secrets)
+  - `~/.openclaw` (wa, key: openclaw_config)
+  - `/etc/passwd`, `/etc/shadow`, `/etc/sudoers`, `/etc/sudoers.d` (wa, key: identity/sudoers)
+  - Privilege escalation (execve with euid=0)
+  - `/var/log/auth.log` (wa, key: auth_log)
+- Enables + starts auditd, loads rules via `augenrules --load`
+
+### `harden-ufw.sh` (AC-17) — Ubuntu only
+- Installs UFW, resets rules
+- Default deny incoming, allow outgoing
+- Allows gateway port (default 18790) from LAN subnet only
+- Allows SSH from LAN subnet only
+- Environment variables: `OPENCLAW_GATEWAY_PORT` (default 18790), `SARGE_LAN_SUBNET` (default 192.168.0.0/24)
+
+### `harden-fail2ban.sh` (SI-3, AC-17) — Ubuntu only
+- Installs fail2ban
+- Writes `/etc/fail2ban/jail.d/sarge.conf` with:
+  - Default: bantime=3600, findtime=600, maxretry=5
+  - sshd jail enabled
+  - openclaw-gateway jail (same auth log, gateway port)
+- Enables + starts fail2ban
+
+### `harden-systemd.sh` (CM-7) — Ubuntu only
+- Creates systemd override for `openclaw-gateway.service`:
+  - NoNewPrivileges, ProtectSystem=strict, ProtectHome=read-only, PrivateTmp, PrivateDevices
+  - ProtectKernelTunables/Modules/ControlGroups, RestrictSUIDSGID, RemoveIPC, RestrictNamespaces
+
+### `harden-firewall-macos.sh` (AC-17) — macOS only
+- Uses `socketfilterfw` (Application Layer Firewall)
+- Global firewall ON, stealth mode ON, block-all OFF (to not brick OpenClaw)
+- Allow signed system binaries + signed downloaded apps
+- Helper function: `alf_set(get_flag, set_flag, desired_pattern, label)` — idempotent state setter
+
+### `harden-ssh-macos.sh` (CM-7) — macOS only
+- Drops `/etc/ssh/sshd_config.d/sarge.conf` with: PermitRootLogin no, PasswordAuthentication no, ChallengeResponseAuthentication no
+- Drop-in approach survives macOS upgrades (in-place edits get clobbered)
+- Preflight: verifies `Include /etc/ssh/sshd_config.d/*` in main sshd_config
+- Warns if current SSH session appears password-based
+- Reloads sshd via `launchctl kickstart -k system/com.openssh.sshd`
+
+---
+
+## Drift Detection
+
+### Snapshot (`drift/snapshot.sh`)
+
+Captures current system state into a JSON document at `~/.sarge/snapshots/snapshot-<ts>.json` and symlinks to `latest.json`.
+
+**JSON structure:**
+```json
+{
+  "timestamp": "ISO-8601",
+  "platform": "ubuntu|macos",
+  "host": "hostname",
+  "kernel": "uname -r",
+  "os": "OS description",
+  "fields": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}
+```
+
+**Ubuntu fields:** `ufw_status`, `auditd_active`, `fail2ban_active`, `openclaw_dir_perm`, `pass_max_days`
+
+**macOS fields:** `firewall_status`, `openclaw_dir_perm`, `sshd_active`, `ssh_permit_root_login`, `ssh_password_auth`, `system_integrity_protection`
+
+### Compare (`drift/compare.sh`)
+
+Reads `latest.json` snapshot, re-probes current state for each field, compares. Uses python3 for JSON field extraction with graceful fallback.
+
+**Function: `check(field, current)`**
+- Reads baseline value from snapshot JSON (`fields.<field>` with fallback to top-level)
+- Compares: match → `[OK]`, mismatch → `[DRIFT]` (increments DRIFT counter)
+
+**Output:** Per-run `drift-report.json` with items array (status, field, baseline, current).
+
+**Exit codes:** 0 = no drift, 2 = drift detected, 1 = no snapshot found.
+
+### Drift Cron (`drift/drift-cron.sh`)
+
+Wrapper for `compare.sh` suitable for cron. Logs to `~/.sarge/drift.log`. On drift detection, sends alert via `openclaw message` if available.
+
+---
+
+## Pre-Hardening Backup & Rollback
+
+### Ubuntu (`scripts/backup-ubuntu.sh`)
+
+**Snapshot tooling preference order:**
+1. Btrfs/ZFS root subvolume snapshot
+2. timeshift
+3. LVM thin snapshot (skips classic LVM — thick provisioning makes snapshots brittle)
+4. File-level snapshot (always collected as safety net)
+
+**File-level capture:** cp -p of every `/etc/` path hardening can touch, plus `ufw status`, `auditctl -l`, `systemctl list-unit-files`, `dpkg --get-selections`, full `/etc/pam.d/`.
+
+**Output directory:** `~/.sarge/runs/<run-id>/backup/` with: `fs/etc/...`, state files, `rollback.sh`, `summary.md`.
+
+**Flags:** `--run-id <id>`, `--unattended`, `--test-mode` (log-only, no destructive snapshot).
+
+**Rollback:** `scripts/rollback-ubuntu.sh` — restores from backup, supports `--run-id` and `--unattended`. `SARGE_ROLLBACK_ROOT=<prefix>` for sandbox testing.
+
+### macOS (`scripts/backup-macos.sh`)
+
+**Layers:**
+1. APFS local snapshot via `tmutil localsnapshot`
+2. Optional Time Machine snapshot via `--time-machine`
+3. File-level capture of `/etc/pam.d/`, sshd_config, sudoers.d, firewall state, launchctl list, defaults domains, SIP/Gatekeeper/FileVault status
+4. Generated `rollback.sh` + `summary.md`
+
+**Status:** Spec'd per issue #30, untested on real macOS hardware.
+
+### Windows (`scripts/backup-windows.ps1`)
+
+**Captures:**
+- System Restore checkpoint
+- Registry exports per tracked policy hive (AC/AU/CM/SC/IA)
+- `secedit /export` of local security policy
+- `auditpol /backup` of audit policy
+- `Get-Service` snapshot
+- `Export-ScheduledTask` for non-Microsoft tasks
+- Auto-generated `rollback.ps1`
+
+**Dependency:** System Protection must be enabled on `%SystemDrive%`. Fails loud (exit 2) if disabled. `--skip-restore-point` to override.
+
+---
+
+## Platform Abstraction Layer
+
+### OS Detection (`lib/platform.sh`)
+
+Exports:
+- `SARGE_OS` — `"ubuntu"` | `"macos"` | `"windows"` | `"unsupported"`
+- `SARGE_OS_VERSION` — version string (e.g. "24.04", "14.5")
+- `SARGE_OS_DESCRIPTION` — human-readable (e.g. "Ubuntu 24.04 LTS")
+
+Functions:
+- `sarge_require_supported_os()` — exit 2 if unsupported
+- `sarge_require_os <os...>` — exit 0 (clean skip) if not in allowed list; silent by default, verbose with `SARGE_VERBOSE=1`
+
+### Dispatcher (`lib/platforms/_dispatch.sh`)
+
+`platform <probe> [args...]` — calls `${SARGE_OS}_<probe>`. Returns exit 127 if probe undefined.
+
+`platform_supports <probe>` — 0 if probe exists, nonzero otherwise. Side-effect free, cheaper than calling the probe.
+
+### Ubuntu Probes (`lib/platforms/ubuntu.sh`)
+
+35+ functions named `ubuntu_<probe>`. Categories:
+- **Filesystem:** `file_perm`, `file_owner`, `world_readable_files_in`
+- **Accounts:** `users_with_empty_passwords`, `uid_zero_non_root_users`, `passwordless_sudo_for_current_user`, `admin_group_name`, `user_in_admin_group`
+- **Firewall:** `firewall_command_available`, `firewall_status_text`, `firewall_active`, `externally_listening_ports`, `port_listening`
+- **Audit:** `audit_daemon_active`, `auditctl_available`, `audit_rules`, `audit_log_path`, `system_logger_active`, `journal_disk_usage`
+- **Packages/Services:** `package_installed`, `unattended_upgrades_config_path`, `pending_package_updates_count`, `pending_security_updates_count`, `service_active`, `service_enabled`, `linux_legacy_service_names`, `sshd_active`, `sshd_config_path`
+- **Authentication:** `login_defs_value`, `pwquality_config_path`, `pwquality_value`, `pam_auth_path`, `pam_faillock_configured`, `faillock_config_path`, `faillock_value`, `session_timeout_setting`
+- **Integrity:** `clamav_installed`, `fail2ban_status`, `verify_checksums`
+- **Drift:** `drift_snapshot_fields`, `drift_check_fields`
+
+### macOS Probes (`lib/platforms/macos.sh`)
+
+20+ functions named `macos_<probe>`. Same categories but with macOS-specific implementations:
+- Uses BSD `stat -f` instead of GNU `stat -c`
+- Uses `dscl` instead of `/etc/shadow` for account management
+- Uses `socketfilterfw` instead of UFW for firewall
+- Uses `lsof -nP -iTCP` instead of `ss -tlnp` for port detection
+- Uses `launchctl` instead of `systemctl` for service management
+- Uses `shasum -a 256` instead of `sha256sum` for checksums
+
+**Intentionally undefined probes** (routes to skipx with macOS rationale):
+- `audit_daemon_active`, `auditctl_available`, `audit_rules`, `audit_log_path` — BSM auditd deprecated, Endpoint Security framework not shell-driveable
+- `journal_disk_usage` — Unified Logging is always-on
+- `package_installed`, `unattended_upgrades_config_path`, `pending_*_count` — softwareupdate/MDM, not apt
+- `login_defs_value`, `pwquality_*`, `pam_faillock_*`, `faillock_*` — Linux-PAM constructs
+- `clamav_installed` — macOS ships XProtect + Gatekeeper
+- `fail2ban_status` — no native macOS analog
+- `linux_legacy_service_names` — systemd unit names don't map to launchd labels
+
+### Windows Context Detection (`lib/platform.ps1`)
+
+`Get-SargeWindowsContext` returns an ordered hashtable:
+```
+version, captured_at, host{edition, build},
+enterprise_context{is_domain_joined, is_aad_joined, is_in_managed_domain, domain_name, intune_managed, gpo_present},
+active_controls{applocker_active, wdac_active, defender_realtime_active, defender_tamper_protection},
+user_context{is_local_admin},
+openclaw{install_path, service_account},
+probe_errors{...}
+```
+
+Helper: `Invoke-SargeProbe -ErrorKey -ProbeErrors -Probe { scriptblock }` — runs probe, captures errors into hashtable, never rethrows.
+
+Helper: `ConvertFrom-DsRegCmdOutput -Lines` — parses `dsregcmd /status` text output into structured hashtable.
+
+---
+
+## Policy Overlay (Windows Phase 1b)
+
+`lib/policy-overlay.ps1` — `Apply-PolicyOverlay` function.
+
+**Purpose:** Re-verdict Phase 1a FAIL/WARN findings as ENFORCED-EXTERNALLY when managed policy (MDM CSP / GPO) provides the enforcement.
+
+**Input:** Findings list (mutated in place), MDM CSP inventory hashtable, gpresult data, AD GPO data.
+
+**Overlay map** (pattern → finding ID):
+- `DeviceLock` → `WIN-AC-11-idle-lock`
+- `AccountLockoutThreshold` → `WIN-AC-7-lockout-threshold`
+- `EnableVirtualizationBasedSecurity` → `WIN-SI-7-wdac-policy`
+- `AllowRealtimeMonitoring` → `WIN-SI-3-defender-realtime`
+- `TamperProtection` → `WIN-SI-3-tamper-protection`
+- `AppLocker` → `WIN-AC-3-workspace-acl`
+
+**Conservative:** Only flips FAIL/WARN → ENFORCED-EXTERNALLY when a matching policy key is present and non-zero. Does not touch PASS or already-EXTN findings. Skips POL-family findings.
+
+**Phase 1b findings:** `WIN-POL-1` (AAD-joined, no MDM), `WIN-POL-2` (policy inventory captured).
+
+---
+
+## Configuration & Baseline
+
+### `baseline/openclaw.json.baseline`
+
+Hardened OpenClaw configuration with inline 800-53 control annotations:
+
+| Setting | Value | NIST Control |
+|---------|-------|-------------|
+| `gateway.bind` | `"lan"` | AC-17 |
+| `gateway.tls` | `true` | SC-8 |
+| `agents.defaults.sandbox.mode` | `"all"` | AC-3, AC-6 |
+| `agents.allowlist` | `[]` | AC-2 |
+| `tools.fs.workspaceOnly` | `true` | AC-3 |
+| `tools.exec.elevated` | `false` | AC-6 |
+| `logging.level` | `"info"` | AU-2 |
+| `logging.includeTimestamp` | `true` | AU-3 |
+| `logging.includeUser` | `true` | AU-3 |
+| `logging.auditActions` | `true` | AU-12 |
+| `memory.encryption` | `true` | SC-28 |
+
+### `baseline/controls.json`
+
+Machine-readable control mapping. 23 controls across 6 families. Each entry:
+```json
+{
+  "id": "AC-2",
+  "family": "AC",
+  "name": "Account Management",
+  "status": "full|partial",
+  "openclaw_settings": ["agents.allowlist", ...],
+  "os_checks": ["getent passwd", ...],
+  "remediation": "Remove unused accounts..."
+}
+```
+
+### Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SARGE_HOST_ONLY` | `0` | Skip agent-scoped checks |
+| `SARGE_REPORT_DIR` | `~/.sarge/reports` | Report output directory |
+| `SARGE_STATE_DIR` | `~/.sarge/state` | State persistence directory |
+| `SARGE_RUN_ID` | Timestamp | Run identifier |
+| `SARGE_RUN_ROOT` | `~/.sarge/runs/<run-id>` | Per-run directory |
+| `SARGE_SNAPSHOT_DIR` | `~/.sarge/snapshots` | Drift snapshot directory |
+| `SARGE_VERBOSE` | `0` | Show skip messages from `sarge_require_os` |
+| `SARGE_LOG_FILE` | `~/.sarge/drift.log` | Drift cron log file |
+| `OPENCLAW_GATEWAY_PORT` | `18790` | Gateway port for SC-8 + UFW checks |
+| `SARGE_LAN_SUBNET` | `192.168.0.0/24` | LAN subnet for UFW rules |
+| `SARGE_ROLLBACK_ROOT` | (unset) | Sandbox prefix for rollback testing |
+
+---
+
+## OpenClaw Integration (Skill)
+
+`SKILL.md` defines Sarge as an OpenClaw skill for ClawhHub (planned at v0.3):
+
+**Invocation phrases:**
+- "Run a Sarge gap analysis" → `assess.sh`
+- "Check for drift since last Sarge snapshot" → `compare.sh`
+- "Apply Sarge hardening scripts" → `install.sh` (interactive)
+- "Show Sarge control mapping for AC-2" → reads `baseline/controls.md`
+- "Take a Sarge snapshot" → `snapshot.sh`
+
+**Security model:** No data leaves the system. No external API calls. No API keys required. Air-gap compatible.
+
+---
+
+## Testing
+
+### Integration Tests (Linux/macOS)
+
+All tests are read-only unless noted. Run from the repo root.
+
+| Test | What it validates |
+|------|------------------|
+| `tests/integration/drift-detection.sh` | Snapshot → compare → verify no-drift + drift-detected paths |
+| `tests/integration/report-validation.sh` | Runs assessment, validates JSON structure + MD output |
+| `tests/integration/hardening-roundtrip.sh` | Assess → harden UFW → reassess → verify PASS. Needs `iptables`/NET_ADMIN; skips in containers. |
+| `tests/integration/host-only-mode.sh` | Validates `--host-only` excludes agent-scoped findings |
+| `tests/integration/backup-ubuntu-smoke.sh` | Ubuntu backup script smoke test |
+| `tests/integration/backup-macos-smoke.sh` | macOS backup dry-run on Linux |
+| `tests/integration/catalog-platform-field.sh` | Validates per-platform fields in findings-catalog.json |
+
+### Pester Tests (Windows)
+
+Under `tests/Pester/`. All use mocked cmdlets — no real system state modified.
+
+| Test file | Coverage |
+|-----------|----------|
+| `windows-ac.Tests.ps1` | Access Control probes + checks |
+| `windows-au.Tests.ps1` | Audit probes + checks |
+| `windows-cm.Tests.ps1` | Configuration Management probes + checks |
+| `windows-ia.Tests.ps1` | Identification & Authentication probes + checks |
+| `windows-sc.Tests.ps1` | System & Communications Protection probes + checks |
+| `windows-si.Tests.ps1` | System & Information Integrity probes + checks |
+| `windows-policy.Tests.ps1` | Policy overlay logic |
+| `windows-host-only.Tests.ps1` | Host-only mode filtering |
+| `backup-windows.Tests.ps1` | Backup script logic |
+
+**Run locally:** `Invoke-Pester -Path tests/Pester`
+
+### CI
+
+GitHub Actions workflow: `.github/workflows/pester-windows.yml`
+- Triggers on push/PR to main when Windows-relevant files change
+- Runs on `windows-latest`
+- Installs Pester 5.5+, runs all tests, uploads NUnit XML results
+
+No Linux/macOS CI workflow wired up yet — integration tests are manual.
+
+---
+
+## Deployment & Packaging
+
+### Installation
+
+```bash
+git clone https://github.com/oscarsixsecllc/sarge.git
+cd sarge
+chmod +x scripts/*.sh assessment/assess.sh assessment/checks/*.sh \
+  assessment/report/report.sh drift/*.sh
+```
+
+### Docker (QA/Test Environment)
+
+`Dockerfile.hardened` — Ubuntu 26.04 base with Node 22, all hardening dependencies pre-installed (auditd, fail2ban, PAM, UFW, OpenClaw), CUPS + avahi for CM-7 testing.
+
+```bash
+docker build -f Dockerfile.hardened -t sarge-qa .
+docker run sarge-qa  # runs assess.sh by default
+```
+
+**Known limitation:** Full hardening in Docker requires systemd as PID 1 with `--privileged --cgroupns=host`. Standard containers skip systemd-dependent modules.
+
+### Checksum Verification
+
+```bash
+cd sarge
+sha256sum --check CHECKSUMS.sha256
+```
+
+To regenerate after intentional changes:
+```bash
+sha256sum scripts/*.sh assessment/**/*.sh > CHECKSUMS.sha256
+```
+
+---
+
+## Exit Code Contract
+
+| Script | Exit 0 | Exit 1 | Exit 2 |
+|--------|--------|--------|--------|
+| `assess.sh` | Assessment ran, report generated (exit 0 ≠ "passed") | Runtime error | Platform not supported |
+| `assess.ps1` | Assessment ran, report generated | Missing probe/build error | — |
+| `install.sh` | Hardening complete (or operator declined) | — | Platform unsupported |
+| `harden-*.sh` | Module applied (or operator declined) | — | — |
+| `snapshot.sh` | Snapshot captured or clean skip | — | Platform unsupported |
+| `compare.sh` | No drift detected or clean skip | No snapshot found | Drift detected |
+| `drift-cron.sh` | Success or clean skip | — | Platform unsupported |
+| `backup-*.sh` | Backup complete | — | System Protection off (Windows) |
+| `rollback-*.sh` | Rollback complete | — | — |
+
+**Key distinction:** `assess.sh` exits 2 on unsupported platforms (loud failure for CI). Drift scripts exit 0 on clean skip (correct behavior under cron).
+
+---
+
+## Hard Rules & Conventions
+
+1. **No data leaves the system.** No telemetry, no callbacks, no external API calls. Ever.
+2. **No API keys or service registration required.**
+3. **All scripts are human-readable.** No obfuscated code, no binary blobs.
+4. **Gap analysis is read-only.** Never writes to system state.
+5. **Hardening scripts require explicit confirmation.** Each module prompts `[y/N]`.
+6. **Hardening scripts are idempotent.** Safe to run multiple times.
+7. **Sudo only for hardening.** `harden-permissions.sh` is the exception — runs as invoking user.
+8. **Platform probes never abort the function.** Failures return empty/null + error entry.
+9. **Check scripts contain assertions, not data acquisition.** Platform files contain probes.
+10. **findings-catalog.json IDs are stable.** Never rename without a migration note.
+11. **Every FAIL/WARN callsite needs a catalog entry.** PASS/SKIP do not.
+12. **Agent-scoped checks are excluded in `--host-only` mode.**
+13. **The per-run folder is self-contained.** Everything needed to understand one run lives under `~/.sarge/runs/<run-id>/`.
+14. **Sarge is scoped to OpenClaw deployments.** It is NOT a general-purpose hardening tool.
+15. **Tier 1 (agent-safety) > Tier 2 (baseline hygiene)** in check prioritization. Both are covered, but agent-safety controls are the primary mission.
+
+---
+
+## Roadmap & Issue Tracker
+
+All tracked at [github.com/oscarsixsecllc/sarge/issues](https://github.com/oscarsixsecllc/sarge/issues).
+
+**Key issues:**
+- **#1** — Expanded SC coverage
+- **#2** — Expanded SI coverage
+- **#12** — Windows roadmap (parent issue)
+- **#28** — Windows pre-hardening backup (spec'd)
+- **#29** — Ubuntu pre-hardening backup (closed)
+- **#30** — macOS pre-hardening backup (spec'd, untested)
+- **#31** — Windows `--inspect-policy` (Phase 1b, implemented)
+- **#34** — Per-run folder layout
+- **#50** — `--host-only` mode
+
+---
+
+*Generated 2026-07-06 by Oscar — Oscar Six Security LLC*

--- a/drift/compare.sh
+++ b/drift/compare.sh
@@ -75,6 +75,58 @@ platform drift_check_fields
 
 echo ""
 
+# Tamper-evident snapshot chain verification. The current snapshot
+# records the hash of the file that WAS latest.json at the moment it was
+# taken (see drift/snapshot.sh). To verify, find that predecessor file
+# on disk — snapshot filenames sort lexicographically by timestamp, so
+# it's the entry immediately before the current target in a sorted
+# listing — and recompute its hash. A mismatch (or a recorded hash that
+# no longer resolves to any file on disk) means either the predecessor
+# was retroactively edited or the chain metadata itself was tampered
+# with. Missing predecessor (first-ever snapshot, "none") is valid.
+CHAIN_VALID="true"
+CURRENT_PREV_HASH=$(python3 - "$LATEST" <<'PY' 2>/dev/null
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        data = json.load(fh)
+    print(data.get("previous_hash", "none"))
+except Exception:
+    print("none")
+PY
+) || true
+CURRENT_PREV_HASH=${CURRENT_PREV_HASH:-none}
+
+CURRENT_TARGET=$(readlink -f "$LATEST" 2>/dev/null || readlink "$LATEST" 2>/dev/null || echo "$LATEST")
+if [[ "$CURRENT_PREV_HASH" == "none" ]]; then
+  echo "[CHAIN] Snapshot integrity: OK (first snapshot in chain)"
+else
+  PREDECESSOR=""
+  while IFS= read -r f; do
+    if [[ "$f" == "$CURRENT_TARGET" ]]; then
+      break
+    fi
+    PREDECESSOR="$f"
+  done < <(find "$SNAPSHOT_DIR" -maxdepth 1 -name 'snapshot-*.json' 2>/dev/null | sort)
+
+  if [[ -z "$PREDECESSOR" ]] || [[ ! -f "$PREDECESSOR" ]]; then
+    # Predecessor no longer exists on disk — can't verify either way.
+    # Don't fail the chain on legitimate pruning/rotation; only flag a
+    # mismatch when we CAN compute a hash and it disagrees.
+    echo "[CHAIN] Snapshot integrity: UNVERIFIABLE (predecessor snapshot not found on disk)"
+  elif command -v sha256sum &>/dev/null; then
+    ACTUAL_PREV_HASH=$(sha256sum "$PREDECESSOR" 2>/dev/null | awk '{print $1}') || true
+    if [[ "$ACTUAL_PREV_HASH" == "$CURRENT_PREV_HASH" ]]; then
+      echo "[CHAIN] Snapshot integrity: OK"
+    else
+      echo "[CHAIN] Snapshot integrity: BROKEN"
+      CHAIN_VALID="false"
+    fi
+  else
+    echo "[CHAIN] Snapshot integrity: UNVERIFIABLE (sha256sum unavailable)"
+  fi
+fi
+
 # Write per-run drift-report.json (issue #34). Self-contained machine-
 # readable view of this compare invocation; the legacy stdout summary
 # above is unchanged so existing log scrapers keep working.
@@ -85,11 +137,13 @@ if command -v jq &>/dev/null; then
     --arg host "$(hostname)" \
     --arg snapshot "$LATEST" \
     --argjson drift_count "$DRIFT" \
+    --argjson chain_valid "$CHAIN_VALID" \
     '{
       timestamp: $ts,
       host: $host,
       baseline_snapshot: $snapshot,
       drift_count: $drift_count,
+      chain_valid: $chain_valid,
       items: (
         split("\n")
         | map(select(length > 0))
@@ -104,6 +158,7 @@ else
     echo "  \"host\": \"$(hostname)\","
     echo "  \"baseline_snapshot\": \"${LATEST}\","
     echo "  \"drift_count\": ${DRIFT},"
+    echo "  \"chain_valid\": ${CHAIN_VALID},"
     echo "  \"items\": ["
     total_lines=$(wc -l < "$DRIFT_ITEMS_FILE" | tr -d ' ')
     idx=0

--- a/drift/snapshot.sh
+++ b/drift/snapshot.sh
@@ -29,6 +29,19 @@ export SARGE_RUN_ID SARGE_RUN_ROOT
 
 echo "[Sarge] Taking baseline snapshot..."
 
+# Tamper-evident snapshot chain (issue: hash-chained snapshots). Hash the
+# outgoing latest.json (resolved through the symlink) BEFORE it gets
+# overwritten below, so each new snapshot records the hash of its
+# predecessor. A follow-up modification to any earlier snapshot file
+# breaks the chain because the *next* snapshot's recorded hash no longer
+# matches the tampered file — compare.sh checks this (see [CHAIN] logic).
+# First-ever snapshot (no prior latest.json) records "none".
+PREVIOUS_HASH="none"
+if [[ -e "$SNAPSHOT_DIR/latest.json" ]] && command -v sha256sum &>/dev/null; then
+  PREVIOUS_HASH=$(sha256sum "$SNAPSHOT_DIR/latest.json" 2>/dev/null | awk '{print $1}') || true
+  PREVIOUS_HASH="${PREVIOUS_HASH:-none}"
+fi
+
 # Platform-specific fields are emitted by `platform drift_snapshot_fields`
 # (defined in lib/platforms/<os>.sh). Nesting under "fields" lets compare.sh
 # enumerate what was captured and lets us evolve per-platform field sets
@@ -39,6 +52,7 @@ cat > "$SNAPSHOT_FILE" <<EOF
   "platform": "${SARGE_OS}",
   "host": "$(hostname)",
   "kernel": "$(uname -r)",
+  "previous_hash": "${PREVIOUS_HASH}",
   "os": "${SARGE_OS_DESCRIPTION}",
   "fields": {
 $(platform drift_snapshot_fields)

--- a/lib/platforms/_dispatch.sh
+++ b/lib/platforms/_dispatch.sh
@@ -181,6 +181,24 @@ for emit_key, path, default in fields:
 PYEOF
 }
 
+# ---------- Control-catalog sync check (shared across platforms) ----------
+#
+# Hashes baseline/controls.json so drift detection can flag when the
+# control catalog changes without a corresponding new snapshot. Path is
+# relative to this file's location (lib/platforms/), not $REPO_ROOT,
+# because this file is sourced from multiple entry points (snapshot.sh,
+# compare.sh, assess.sh) that don't all export REPO_ROOT the same way.
+_sarge_catalog_sync_field() {
+  local catalog="${_SARGE_PLATFORMS_DIR}/../../baseline/controls.json"
+  local hash
+  if [[ ! -r "$catalog" ]] || ! command -v sha256sum &>/dev/null; then
+    echo "catalog_controls_sha256=missing"
+    return 0
+  fi
+  hash=$(sha256sum "$catalog" 2>/dev/null | awk '{print $1}') || true
+  echo "catalog_controls_sha256=${hash:-missing}"
+}
+
 # ---------- Drift field plumbing (shared across platforms) ----------
 #
 # Each platform defines `_<os>_drift_fields` that emits one `key=value`

--- a/lib/platforms/macos.sh
+++ b/lib/platforms/macos.sh
@@ -157,6 +157,14 @@ macos_port_listening() {
 #   audit_daemon_active, auditctl_available, audit_rules,
 #   audit_log_path, journal_disk_usage
 #
+# Same rationale extends to the AU-4/5/7/8/11 probes added for issue #72
+# (log_partition_free_pct, auditd_config_path, auditd_config_value,
+# journalctl_available, ausearch_available, syslog_forwarding_configured,
+# time_sync_active, time_sync_status_text, logrotate_audit_config_path,
+# logrotate_rotate_count) — auditd.conf, logrotate, and journalctl/
+# ausearch are Linux constructs with no macOS analog; NTP/time sync on
+# macOS is MDM/System Settings-managed, not shell-probeable the same way.
+#
 # Unified Logging (`log`) is always-on on macOS — there is no "off"
 # state — so AU-2 "system logging exists" is structurally satisfied.
 # We map system_logger_active to a successful exit so check-au.sh's
@@ -249,6 +257,7 @@ macos_verify_checksums() { shasum -a 256 -c "$1" --quiet 2>/dev/null; }
 # from grep/awk when there's no match).
 _macos_drift_fields() {
   local fw perm sshd_state sshd_conf permit_root pw_auth sip
+  local dup_uid_count ssh_protocol_1 ia_oc_config auth_mode session_idle_ttl
   fw=$(macos_firewall_status_text 2>/dev/null | head -1 | tr -d '\n') || true
   perm=$(stat -f '%A' "$HOME/.openclaw" 2>/dev/null) || true
   if launchctl print system/com.openssh.sshd &>/dev/null; then
@@ -260,14 +269,40 @@ _macos_drift_fields() {
   if [[ -r "$sshd_conf" ]]; then
     permit_root=$(grep -iE '^PermitRootLogin' "$sshd_conf" 2>/dev/null | awk '{print $2}' | head -1) || true
     pw_auth=$(grep -iE '^PasswordAuthentication' "$sshd_conf" 2>/dev/null | awk '{print $2}' | head -1) || true
+    if grep -qiE "^[[:space:]]*Protocol[[:space:]]+1(\b|,)" "$sshd_conf" 2>/dev/null; then
+      ssh_protocol_1="yes"
+    else
+      ssh_protocol_1="no"
+    fi
   fi
   sip=$(csrutil status 2>/dev/null | awk -F': ' '/status:/{print $2}' | tr -d '.') || true
+  # IA-4: duplicate UID count (identifier reuse signal). /etc/passwd on
+  # macOS only carries local accounts (Open Directory holds the rest),
+  # but a duplicate here is still a hygiene signal worth tracking.
+  dup_uid_count=$(awk -F: '{print $3}' /etc/passwd 2>/dev/null | sort | uniq -d | wc -l | tr -d '[:space:]') || true
+  # IA-8 / IA-11: OpenClaw gateway auth mode + session idle TTL. Same
+  # openclaw.json -> config.json fallback used by check-ia.sh and
+  # check-sc.sh (issue #61).
+  for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+    if [[ -f "$candidate" ]]; then
+      ia_oc_config="$candidate"
+      break
+    fi
+  done
+  if [[ -n "${ia_oc_config:-}" ]]; then
+    auth_mode=$(grep -oE '"mode"[[:space:]]*:[[:space:]]*"[^"]*"' "$ia_oc_config" 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)"$/\1/') || true
+    session_idle_ttl=$(grep -oE '"sessionIdleTtlMs"[[:space:]]*:[[:space:]]*[0-9]+' "$ia_oc_config" 2>/dev/null | grep -oE '[0-9]+$' | head -1) || true
+  fi
   echo "firewall_status=${fw:-unknown}"
   echo "openclaw_dir_perm=${perm:-unknown}"
   echo "sshd_active=${sshd_state}"
   echo "ssh_permit_root_login=${permit_root:-unset}"
   echo "ssh_password_auth=${pw_auth:-unset}"
   echo "system_integrity_protection=${sip:-unknown}"
+  echo "duplicate_uid_count=${dup_uid_count:-unknown}"
+  echo "ssh_protocol_1_configured=${ssh_protocol_1:-unknown}"
+  echo "gateway_auth_mode=${auth_mode:-unknown}"
+  echo "gateway_session_idle_ttl_ms=${session_idle_ttl:-unknown}"
 }
 
 # Snapshot + compare dispatch entry points. The actual loops live in

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -286,6 +286,29 @@ ubuntu_fail2ban_status() {
 # Caller is responsible for `cd`'ing to the repo root before calling.
 ubuntu_verify_checksums() { sha256sum --check "$1" --quiet 2>/dev/null; }
 
+# 0 if apt is available at all (gates the SI-7 package-integrity checks).
+ubuntu_apt_config_available() { command -v apt-config &>/dev/null; }
+
+# Value of APT::Get::AllowUnauthenticated, lowercased. Empty if unset —
+# apt treats unset the same as "false" (signature checks enforced).
+ubuntu_apt_allow_unauthenticated() {
+  apt-config dump 2>/dev/null | grep -i "AllowUnauthenticated" | awk -F'"' '{print $2}' | tr '[:upper:]' '[:lower:]'
+}
+
+# Count of trusted apt GPG keyring files (modern /etc/apt/trusted.gpg.d/
+# *.gpg plus the legacy single-file /etc/apt/trusted.gpg, if present).
+# Always prints a single integer.
+ubuntu_apt_trusted_keys_count() {
+  local count=0
+  count=$(find /etc/apt/trusted.gpg.d -maxdepth 1 -name "*.gpg" 2>/dev/null | wc -l | tr -d '[:space:]')
+  [[ -f /etc/apt/trusted.gpg ]] && count=$((count + 1))
+  echo "$count"
+}
+
+# Value of /proc/sys/kernel/randomize_va_space: 2=full ASLR, 1=partial,
+# 0=disabled. Empty if the file doesn't exist (non-Linux, exotic kernel).
+ubuntu_aslr_setting() { cat /proc/sys/kernel/randomize_va_space 2>/dev/null; }
+
 # ---------- Drift (CM-2) ----------
 #
 # Emits the platform-specific "fields" block consumed by drift/snapshot.sh
@@ -307,6 +330,7 @@ ubuntu_verify_checksums() { sha256sum --check "$1" --quiet 2>/dev/null; }
 _ubuntu_drift_fields() {
   local ufw auditd f2b perm pmd log_free ntp_sync disk_full_action rotate_count
   local dup_uid_count ssh_protocol_1 ia_oc_config auth_mode session_idle_ttl
+  local aslr apt_allow_unauth
   ufw=$(ufw status 2>/dev/null | head -1) || true
   auditd=$(systemctl is-active auditd 2>/dev/null) || true
   f2b=$(systemctl is-active fail2ban 2>/dev/null) || true
@@ -350,6 +374,40 @@ _ubuntu_drift_fields() {
   echo "ssh_protocol_1_configured=${ssh_protocol_1:-unknown}"
   echo "gateway_auth_mode=${auth_mode:-unknown}"
   echo "gateway_session_idle_ttl_ms=${session_idle_ttl:-unknown}"
+  # SI-16: ASLR setting (memory protection)
+  aslr=$(ubuntu_aslr_setting) || true
+  echo "aslr_setting=${aslr:-unknown}"
+  # SI-7: apt unauthenticated-package allowance
+  apt_allow_unauth=$(ubuntu_apt_allow_unauthenticated) || true
+  echo "apt_allow_unauthenticated=${apt_allow_unauth:-unknown}"
+  # SA-22: OS + Node.js runtime versions (EOL tracking inputs)
+  echo "os_version=${SARGE_OS_VERSION:-unknown}"
+  echo "node_version=$(node --version 2>/dev/null | tr -d 'v')"
+  # SA-9: external MCP server count. Same openclaw.json -> config.json
+  # fallback used by check-sa.sh / check-ia.sh (issue #61).
+  local sa_oc_config mcp_server_count
+  for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+    if [[ -f "$candidate" ]]; then
+      sa_oc_config="$candidate"
+      break
+    fi
+  done
+  if [[ -n "${sa_oc_config:-}" ]]; then
+    if command -v jq &>/dev/null; then
+      mcp_server_count=$(jq -r '(.mcp.servers // {}) | to_entries | map(select(.key | startswith("_") | not)) | length' "$sa_oc_config" 2>/dev/null)
+    fi
+  fi
+  echo "mcp_external_server_count=${mcp_server_count:-unknown}"
+  # MP-6: media retention TTL
+  local media_ttl
+  if [[ -n "${sa_oc_config:-}" ]]; then
+    media_ttl=$(grep -oE '"ttlHours"[[:space:]]*:[[:space:]]*[0-9]+' "$sa_oc_config" 2>/dev/null | grep -oE '[0-9]+$' | head -1) || true
+  fi
+  echo "media_ttl_hours=${media_ttl:-unknown}"
+  # SR-11: apt trusted-key count (reuses SI-7's probe)
+  local apt_trusted_keys
+  apt_trusted_keys=$(ubuntu_apt_trusted_keys_count) || true
+  echo "apt_trusted_keys_count=${apt_trusted_keys:-unknown}"
 }
 
 # Snapshot + compare dispatch entry points. The actual loops live in

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -114,6 +114,62 @@ ubuntu_system_logger_active() { systemctl is-active --quiet systemd-journald 2>/
 # Output of `journalctl --disk-usage` (used to detect persisted journals).
 ubuntu_journal_disk_usage() { journalctl --disk-usage 2>/dev/null; }
 
+# Percentage of free space on the partition backing the audit log
+# directory (falls back to /var/log if /var/log/audit doesn't exist).
+# Prints an integer 0-100. Empty if df is unavailable or the path is
+# missing entirely.
+ubuntu_log_partition_free_pct() {
+  local target="/var/log/audit"
+  [[ -d "$target" ]] || target="/var/log"
+  df -P "$target" 2>/dev/null | awk 'NR==2 { gsub("%","",$5); print 100-$5 }'
+}
+
+ubuntu_auditd_config_path() { echo "/etc/audit/auditd.conf"; }
+
+# Read `key = value` from auditd.conf (case-insensitive key match). Empty
+# if unset or the file doesn't exist.
+ubuntu_auditd_config_value() {
+  grep -i "^$1" "$(ubuntu_auditd_config_path)" 2>/dev/null | awk -F= '{print $2}' | tr -d ' '
+}
+
+ubuntu_journalctl_available() { command -v journalctl &>/dev/null; }
+ubuntu_ausearch_available()   { command -v ausearch &>/dev/null; }
+
+# 0 if rsyslog is configured to forward logs to a remote collector
+# (legacy `*.* @host` / `@@host` syntax or modern omfwd action blocks).
+ubuntu_syslog_forwarding_configured() {
+  grep -rhE '^\s*\*\.\*\s+@|action\(type="omfwd"' /etc/rsyslog.conf /etc/rsyslog.d/*.conf 2>/dev/null | grep -q .
+}
+
+# 0 if the system clock is synchronized via NTP (timedatectl first,
+# chrony as fallback for hosts running chronyd directly).
+ubuntu_time_sync_active() {
+  local synced
+  synced=$(timedatectl show -p NTPSynchronized --value 2>/dev/null)
+  [[ "$synced" == "yes" ]] && return 0
+  chronyc tracking 2>/dev/null | grep -qi "Leap status.*Normal"
+}
+
+# Human-readable time sync status, for diagnostics only.
+ubuntu_time_sync_status_text() {
+  timedatectl status 2>/dev/null || chronyc tracking 2>/dev/null || echo ""
+}
+
+# Path to the logrotate config governing the audit log, if any exists.
+ubuntu_logrotate_audit_config_path() {
+  local f
+  for f in /etc/logrotate.d/auditd /etc/logrotate.d/audit; do
+    [[ -f "$f" ]] && { echo "$f"; return 0; }
+  done
+  echo "/etc/logrotate.d/auditd"
+}
+
+# Read the `rotate N` cycle count from a logrotate config file. Empty if
+# unset or the file doesn't exist.
+ubuntu_logrotate_rotate_count() {
+  grep -E "^\s*rotate\s+[0-9]+" "$1" 2>/dev/null | awk '{print $2}' | head -1
+}
+
 # ---------- Packages / Services (CM family + SI family) ----------
 
 # 0 if a deb package is installed.
@@ -249,17 +305,51 @@ ubuntu_verify_checksums() { sha256sum --check "$1" --quiet 2>/dev/null; }
 #      pipeline exit is from head (zero on empty stdin). Capture-then-
 #      default sidesteps that entirely.
 _ubuntu_drift_fields() {
-  local ufw auditd f2b perm pmd
+  local ufw auditd f2b perm pmd log_free ntp_sync disk_full_action rotate_count
+  local dup_uid_count ssh_protocol_1 ia_oc_config auth_mode session_idle_ttl
   ufw=$(ufw status 2>/dev/null | head -1) || true
   auditd=$(systemctl is-active auditd 2>/dev/null) || true
   f2b=$(systemctl is-active fail2ban 2>/dev/null) || true
   perm=$(stat -c '%a' "$HOME/.openclaw" 2>/dev/null) || true
   pmd=$(grep ^PASS_MAX_DAYS /etc/login.defs 2>/dev/null | awk '{print $2}') || true
+  log_free=$(ubuntu_log_partition_free_pct) || true
+  ntp_sync=$(ubuntu_time_sync_active && echo "yes" || echo "no") || true
+  disk_full_action=$(ubuntu_auditd_config_value "disk_full_action") || true
+  rotate_count=$(ubuntu_logrotate_rotate_count "$(ubuntu_logrotate_audit_config_path)") || true
+  # IA-4: duplicate UID count (identifier reuse signal)
+  dup_uid_count=$(awk -F: '{print $3}' /etc/passwd 2>/dev/null | sort | uniq -d | wc -l | tr -d '[:space:]') || true
+  # IA-7: whether SSHv1 (Protocol 1) is explicitly configured
+  if grep -qiE "^[[:space:]]*Protocol[[:space:]]+1(\b|,)" /etc/ssh/sshd_config 2>/dev/null; then
+    ssh_protocol_1="yes"
+  else
+    ssh_protocol_1="no"
+  fi
+  # IA-8 / IA-11: OpenClaw gateway auth mode + session idle TTL. Same
+  # openclaw.json -> config.json fallback used by check-ia.sh and
+  # check-sc.sh (issue #61).
+  for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+    if [[ -f "$candidate" ]]; then
+      ia_oc_config="$candidate"
+      break
+    fi
+  done
+  if [[ -n "${ia_oc_config:-}" ]]; then
+    auth_mode=$(grep -oE '"mode"[[:space:]]*:[[:space:]]*"[^"]*"' "$ia_oc_config" 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)"$/\1/') || true
+    session_idle_ttl=$(grep -oE '"sessionIdleTtlMs"[[:space:]]*:[[:space:]]*[0-9]+' "$ia_oc_config" 2>/dev/null | grep -oE '[0-9]+$' | head -1) || true
+  fi
   echo "ufw_status=${ufw:-unknown}"
   echo "auditd_active=${auditd:-unknown}"
   echo "fail2ban_active=${f2b:-unknown}"
   echo "openclaw_dir_perm=${perm:-unknown}"
   echo "pass_max_days=${pmd:-unknown}"
+  echo "log_partition_free_pct=${log_free:-unknown}"
+  echo "ntp_synchronized=${ntp_sync:-unknown}"
+  echo "auditd_disk_full_action=${disk_full_action:-unknown}"
+  echo "auditd_log_rotate_count=${rotate_count:-unknown}"
+  echo "duplicate_uid_count=${dup_uid_count:-unknown}"
+  echo "ssh_protocol_1_configured=${ssh_protocol_1:-unknown}"
+  echo "gateway_auth_mode=${auth_mode:-unknown}"
+  echo "gateway_session_idle_ttl_ms=${session_idle_ttl:-unknown}"
 }
 
 # Snapshot + compare dispatch entry points. The actual loops live in

--- a/lib/platforms/ubuntu.sh
+++ b/lib/platforms/ubuntu.sh
@@ -327,6 +327,48 @@ ubuntu_aslr_setting() { cat /proc/sys/kernel/randomize_va_space 2>/dev/null; }
 #      fallback when the *left* side fails — without `pipefail` the
 #      pipeline exit is from head (zero on empty stdin). Capture-then-
 #      default sidesteps that entirely.
+# SHA-256 of a single file's contents. Prints "missing" if the file
+# doesn't exist, isn't readable, or `sha256sum` isn't available — never
+# fails under `set -euo pipefail`.
+_ubuntu_sha256_of_file() {
+  local path="$1" hash
+  if [[ ! -r "$path" ]] || ! command -v sha256sum &>/dev/null; then
+    echo "missing"
+    return 0
+  fi
+  hash=$(sha256sum "$path" 2>/dev/null | awk '{print $1}') || true
+  echo "${hash:-missing}"
+}
+
+# SHA-256 of the concatenated, sorted contents of a glob of files (e.g.
+# a rules.d/*.rules directory). Sorting the file list first makes the
+# hash stable regardless of filesystem enumeration order. Prints
+# "missing" if no files match or sha256sum is unavailable.
+_ubuntu_sha256_of_glob() {
+  local -a files=("$@")
+  local existing=() f hash
+  command -v sha256sum &>/dev/null || { echo "missing"; return 0; }
+  for f in "${files[@]}"; do
+    [[ -r "$f" ]] && existing+=("$f")
+  done
+  if [[ ${#existing[@]} -eq 0 ]]; then
+    echo "missing"
+    return 0
+  fi
+  hash=$(cat "$(printf '%s\n' "${existing[@]}" | sort)" 2>/dev/null | sha256sum | awk '{print $1}') || true
+  echo "${hash:-missing}"
+}
+
+# SHA-256 of a command's (sorted) stdout. Used for package/service
+# inventory hashing. Prints "missing" if the command fails or
+# sha256sum is unavailable — never fails under `set -euo pipefail`.
+_ubuntu_sha256_of_command() {
+  local hash
+  command -v sha256sum &>/dev/null || { echo "missing"; return 0; }
+  hash=$("$@" 2>/dev/null | sort | sha256sum | awk '{print $1}') || true
+  echo "${hash:-missing}"
+}
+
 _ubuntu_drift_fields() {
   local ufw auditd f2b perm pmd log_free ntp_sync disk_full_action rotate_count
   local dup_uid_count ssh_protocol_1 ia_oc_config auth_mode session_idle_ttl
@@ -409,8 +451,43 @@ _ubuntu_drift_fields() {
   apt_trusted_keys=$(ubuntu_apt_trusted_keys_count) || true
   echo "apt_trusted_keys_count=${apt_trusted_keys:-unknown}"
 
+  # SI-7 / CM-2: file-integrity hashes for security-critical files.
+  # `sha256sum` prints "missing" for the value when the file doesn't
+  # exist or hashing fails, so callers under `set -euo pipefail` never
+  # abort on an absent file (some hosts don't run auditd, ufw, etc.).
+  local oc_json_hash sshd_hash pam_hash audit_hash ufw_hash
+  local oc_json_path
+  for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+    if [[ -f "$candidate" ]]; then
+      oc_json_path="$candidate"
+      break
+    fi
+  done
+  oc_json_hash=$(_ubuntu_sha256_of_file "${oc_json_path:-$HOME/.openclaw/openclaw.json}")
+  sshd_hash=$(_ubuntu_sha256_of_file "/etc/ssh/sshd_config")
+  pam_hash=$(_ubuntu_sha256_of_file "/etc/pam.d/common-auth")
+  audit_hash=$(_ubuntu_sha256_of_glob "/etc/audit/rules.d/"*.rules)
+  ufw_hash=$(_ubuntu_sha256_of_file "/etc/ufw/user.rules")
+  echo "openclaw_json_sha256=${oc_json_hash}"
+  echo "sshd_config_sha256=${sshd_hash}"
+  echo "pam_common_auth_sha256=${pam_hash}"
+  echo "audit_rules_sha256=${audit_hash}"
+  echo "ufw_rules_sha256=${ufw_hash}"
+
+  # CM-8: package + service inventory hashes. Detects package
+  # additions/removals and enabled-service changes between snapshots
+  # without storing the full (large) inventory in the snapshot itself.
+  local pkg_hash svc_hash
+  pkg_hash=$(_ubuntu_sha256_of_command dpkg --get-selections)
+  svc_hash=$(_ubuntu_sha256_of_command systemctl list-unit-files --state=enabled --no-legend)
+  echo "installed_packages_sha256=${pkg_hash}"
+  echo "enabled_services_sha256=${svc_hash}"
+
   # OpenClaw config surface (shared across platforms, defined in _dispatch.sh)
   _sarge_openclaw_config_drift_fields
+
+  # CM-2: control-catalog sync check (shared across platforms, _dispatch.sh)
+  _sarge_catalog_sync_field
 }
 
 # Snapshot + compare dispatch entry points. The actual loops live in

--- a/tests/integration/drift-detection.sh
+++ b/tests/integration/drift-detection.sh
@@ -119,6 +119,113 @@ fi
 [[ "$dc" -gt 0 ]] || fail "drift-report.json drift_count should be > 0, got $dc"
 ok "drift-report.json shows drift_count > 0"
 
+# --- File integrity hash fields (issue: file hashing) ---
+for field in openclaw_json_sha256 sshd_config_sha256 pam_common_auth_sha256 \
+             audit_rules_sha256 ufw_rules_sha256; do
+  if command -v jq &>/dev/null; then
+    val=$(jq -r ".fields.${field} // empty" "$LATEST" 2>/dev/null)
+  else
+    val=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+v=d.get('fields',{}).get(sys.argv[2])
+if v is not None: print(v)
+" "$LATEST" "$field" 2>/dev/null)
+  fi
+  [[ -n "$val" ]] || fail "snapshot JSON missing file-hash field: $field"
+done
+ok "snapshot JSON has file-integrity hash fields"
+
+# --- Package/service inventory hashes (issue: inventory tracking) ---
+for field in installed_packages_sha256 enabled_services_sha256; do
+  if command -v jq &>/dev/null; then
+    val=$(jq -r ".fields.${field} // empty" "$LATEST" 2>/dev/null)
+  else
+    val=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+v=d.get('fields',{}).get(sys.argv[2])
+if v is not None: print(v)
+" "$LATEST" "$field" 2>/dev/null)
+  fi
+  [[ -n "$val" ]] || fail "snapshot JSON missing inventory-hash field: $field"
+done
+ok "snapshot JSON has package/service inventory hash fields"
+
+# --- Control-catalog sync field (issue: catalog sync check) ---
+if command -v jq &>/dev/null; then
+  cat_val=$(jq -r '.fields.catalog_controls_sha256 // empty' "$LATEST" 2>/dev/null)
+else
+  cat_val=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+v=d.get('fields',{}).get('catalog_controls_sha256')
+if v is not None: print(v)
+" "$LATEST" 2>/dev/null)
+fi
+[[ -n "$cat_val" ]] || fail "snapshot JSON missing catalog_controls_sha256 field"
+ok "snapshot JSON has catalog sync field (catalog_controls_sha256)"
+
+# --- Tamper-evident snapshot chain (issue: hash-chained snapshots) ---
+# Uses its own fresh SARGE_SNAPSHOT_DIR: the drift-simulation test above
+# rewrites latest.json in place (jq output moved onto the symlink path),
+# which turns latest.json from a symlink into a plain file and would
+# otherwise confuse the chain's file-identity assumptions here.
+CHAIN_SNAPSHOT_DIR="$TMPDIR_DRIFT/snapshots-chain"
+mkdir -p "$CHAIN_SNAPSHOT_DIR"
+export SARGE_SNAPSHOT_DIR="$CHAIN_SNAPSHOT_DIR"
+CHAIN_LATEST="$CHAIN_SNAPSHOT_DIR/latest.json"
+
+export SARGE_RUN_ROOT="$TMPDIR_DRIFT/run-chain1"
+export SARGE_RUN_ID="test-chain1-$$"
+mkdir -p "$SARGE_RUN_ROOT"
+bash "$REPO_ROOT/drift/snapshot.sh" > /dev/null 2>&1 || fail "first chain snapshot.sh exited non-zero"
+
+# First-ever snapshot in a fresh SARGE_SNAPSHOT_DIR has no predecessor,
+# so previous_hash must be the literal "none".
+if command -v jq &>/dev/null; then
+  prev_hash=$(jq -r '.previous_hash // empty' "$CHAIN_LATEST" 2>/dev/null)
+else
+  prev_hash=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+v=d.get('previous_hash')
+if v is not None: print(v)
+" "$CHAIN_LATEST" 2>/dev/null)
+fi
+[[ "$prev_hash" == "none" ]] || fail "first snapshot previous_hash should be 'none', got '$prev_hash'"
+ok "first snapshot previous_hash is 'none'"
+
+# Take a second snapshot and confirm its previous_hash is a real sha256
+# (not 'none') and the chain reports OK.
+export SARGE_RUN_ROOT="$TMPDIR_DRIFT/run-chain2"
+export SARGE_RUN_ID="test-chain2-$$"
+mkdir -p "$SARGE_RUN_ROOT"
+sleep 1
+bash "$REPO_ROOT/drift/snapshot.sh" > /dev/null 2>&1 || fail "second snapshot.sh exited non-zero"
+if command -v jq &>/dev/null; then
+  prev_hash2=$(jq -r '.previous_hash // empty' "$CHAIN_LATEST" 2>/dev/null)
+else
+  prev_hash2=$(python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+v=d.get('previous_hash')
+if v is not None: print(v)
+" "$CHAIN_LATEST" 2>/dev/null)
+fi
+[[ -n "$prev_hash2" && "$prev_hash2" != "none" ]] || fail "second snapshot previous_hash should be a real hash, got '$prev_hash2'"
+ok "second snapshot previous_hash records predecessor's hash"
+
+export SARGE_RUN_ROOT="$TMPDIR_DRIFT/run-chain-ok"
+export SARGE_RUN_ID="test-chain-ok-$$"
+mkdir -p "$SARGE_RUN_ROOT"
+CHAIN_OUT=$(bash "$REPO_ROOT/drift/compare.sh" 2>&1)
+echo "$CHAIN_OUT" | grep -q "\[CHAIN\] Snapshot integrity: OK" || fail "expected intact chain to report OK, got: $CHAIN_OUT"
+ok "compare.sh reports chain OK for an untampered chain"
+
+# Restore the original snapshot dir for anything after this point.
+export SARGE_SNAPSHOT_DIR="$TMPDIR_DRIFT/snapshots"
+
 echo ""
 echo "drift-detection: $PASS/$TESTS passed"
 [[ "$PASS" -eq "$TESTS" ]]


### PR DESCRIPTION
## Summary

Expands Sarge from 31 controls / 8 families to **63 controls / 12 families** with full documentation.

**Phase 1 — Small wins (17 controls):**
- AU: +5 (AU-4, AU-5, AU-7, AU-8, AU-11)
- IA: +4 (IA-4, IA-7, IA-8, IA-11)
- SI: +2 (SI-7, SI-16)
- CA: +1 (CA-9)
- CP: +1 (CP-9)
- SA: +2 new family (SA-9, SA-22)
- MP: +1 new family (MP-6)
- SR: +1 new family (SR-11)

**Phase 2 — AC/CM expansion (12 controls):**
- AC: +8 (AC-4, AC-5, AC-7, AC-8, AC-10, AC-11, AC-12, AC-14)
- CM: +4 (CM-3, CM-5, CM-8, CM-11)

**Phase 3 — SC expansion + RA (8 controls):**
- SC: +7 (SC-2, SC-4, SC-12, SC-13, SC-15, SC-23, SC-39)
- RA: +1 new family (RA-5)

**Documentation:**
- README: new "NIST 800-53 Rev 5 Control Coverage" section with per-control detail (OpenClaw settings, OS checks, remediation)
- SARGE-REFERENCE.md version bumped from 0.1.1 to 0.7.0
- 7 non-automatable families (AT, IR, MA, PE, PL, PM, PS) documented with rationale

**Files changed:** 17 files, +2,450 lines
- 13 new/expanded check scripts in `assessment/checks/`
- Updated `baseline/controls.json` and `assessment/findings-catalog.json`
- Platform probe functions in `lib/platforms/ubuntu.sh` and `lib/platforms/macos.sh`

## Test plan

- [ ] report-validation (12/12 passing)
- [ ] catalog-platform-field (5/5 passing)
- [ ] drift-detection (8/8 passing)
- [ ] agent-safety-checks (19/19 passing)
- [ ] Hardening roundtrip on o6vm01 (needs systemd, can't run in Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)