### PR TITLE
feat: AC/CM expansion + restore CI/release workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug Report
+description: Report a bug in Sarge (false positive, false negative, script error, etc.)
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill out the details below so we can reproduce and fix it.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of Sarge is affected?
+      options:
+        - Assessment (assess.sh / assess.ps1)
+        - Hardening (scripts/harden-*.sh)
+        - Drift detection (drift/)
+        - Findings catalog (findings-catalog.json)
+        - Backup / Rollback
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: e.g., Ubuntu 24.04 LTS x86_64, macOS 15.1 arm64, Windows 11 23H2
+      placeholder: Ubuntu 24.04 LTS x86_64
+    validations:
+      required: true
+
+  - type: input
+    id: openclaw-version
+    attributes:
+      label: OpenClaw Version
+      description: Output of `openclaw --version`, or "N/A" if running --host-only
+      placeholder: 2026.8.2
+    validations:
+      required: true
+
+  - type: input
+    id: sarge-version
+    attributes:
+      label: Sarge Version
+      description: Git tag or commit hash (run `git describe --tags --always`)
+      placeholder: v0.9.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Exact commands or actions that trigger the bug.
+      placeholder: |
+        1. Run `./assessment/assess.sh`
+        2. Observe check AC-3-openclaw-dir-perm
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens? Include error output if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Anything else that might help (Docker vs VM, relevant config, screenshots, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest an improvement to Sarge
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the feature you'd like to see in Sarge.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Sarge does this affect?
+      options:
+        - Assessment engine
+        - Hardening scripts
+        - Drift detection
+        - Report output / formatting
+        - Platform support
+        - OpenClaw integration / SKILL.md
+        - Documentation
+        - Testing
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Use Case
+      description: What problem does this solve, or what use case does it enable?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you considered and why they don't work as well.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, links, related issues, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new_control.yml
+++ b/.github/ISSUE_TEMPLATE/new_control.yml
@@ -1,0 +1,107 @@
+name: New Control Request
+description: Request coverage for a new NIST 800-53 Rev 5 control
+title: "[Control] "
+labels: ["enhancement", "new-control"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to request that Sarge add coverage for a new NIST 800-53 Rev 5 control.
+
+  - type: input
+    id: control-id
+    attributes:
+      label: Control ID
+      description: The NIST 800-53 Rev 5 control identifier
+      placeholder: AC-19
+    validations:
+      required: true
+
+  - type: input
+    id: control-name
+    attributes:
+      label: Control Name
+      description: Full name from NIST SP 800-53 Rev 5
+      placeholder: Access Control for Mobile Devices
+    validations:
+      required: true
+
+  - type: dropdown
+    id: family
+    attributes:
+      label: Control Family
+      options:
+        - AC (Access Control)
+        - AU (Audit and Accountability)
+        - CA (Assessment, Authorization, and Monitoring)
+        - CM (Configuration Management)
+        - CP (Contingency Planning)
+        - IA (Identification and Authentication)
+        - MP (Media Protection)
+        - RA (Risk Assessment)
+        - SA (System and Services Acquisition)
+        - SC (System and Communications Protection)
+        - SI (System and Information Integrity)
+        - SR (Supply Chain Risk Management)
+        - AS (Agent Safety overlay)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-to-check
+    attributes:
+      label: What to Check
+      description: |
+        What system state, config value, or OpenClaw setting should Sarge inspect?
+        Include specific files, commands, or config keys.
+      placeholder: |
+        - Check if /etc/some/config has setting X
+        - Verify OpenClaw config key `some.setting` is set to Y
+        - Run `some-command` and verify output
+    validations:
+      required: true
+
+  - type: textarea
+    id: automation-approach
+    attributes:
+      label: Automation Approach
+      description: |
+        How could this check be automated? What commands or file inspections would produce a pass/fail verdict?
+        If part of the control requires human review, note which parts are automatable and which are not.
+      placeholder: |
+        Automatable: Check file permissions with `stat`, verify config key with `jq`
+        Manual: Policy document review for organizational procedures
+    validations:
+      required: true
+
+  - type: dropdown
+    id: coverage-level
+    attributes:
+      label: Expected Coverage Level
+      description: Can the entire control be automated, or only part of it?
+      options:
+        - Full (entirely automatable)
+        - Partial (some aspects require human review)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Is this a host-level check or an OpenClaw agent-runtime check?
+      options:
+        - Host (OS-level, applies in --host-only mode)
+        - Agent (OpenClaw-specific, skipped in --host-only mode)
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: nist-reference
+    attributes:
+      label: NIST Reference
+      description: Link or citation to the NIST SP 800-53 Rev 5 control definition
+      placeholder: https://csf.tools/reference/nist-sp-800-53/r5/ac/ac-19/
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## What This Changes
+
+<!-- Brief description of the change and why it's needed -->
+
+## 800-53 Control(s) Affected
+
+<!-- e.g., AC-2, CM-7, AS-3. Write "None" if this is a docs/infra-only change -->
+
+## Test Results
+
+- **OS:** <!-- e.g., Ubuntu 24.04 LTS x86_64 -->
+- **OpenClaw version:** <!-- e.g., 2026.8.2, or N/A if --host-only -->
+- **Sarge version/branch:** <!-- e.g., v0.9.0 + this PR -->
+- **Assessment before:** <!-- PASS/WARN/FAIL/SKIP counts -->
+- **Assessment after:** <!-- PASS/WARN/FAIL/SKIP counts -->
+
+## PR Checklist
+
+- [ ] Integration tests pass (`report-validation.sh`, `catalog-platform-field.sh`)
+- [ ] New check IDs follow naming convention (`<FAMILY>-<NUMBER>-<slug>`)
+- [ ] `findings-catalog.json` updated for every new `failx`/`warnx` callsite
+- [ ] `baseline/controls.json` updated (if adding a new control)
+- [ ] Drift tracking updated in `drift/snapshot.sh` and `drift/compare.sh` (if applicable)
+- [ ] `CHECKSUMS.sha256` regenerated (if scripts changed)
+- [ ] Documentation updated (README.md, controls.md, or docs/)
+- [ ] No external network calls, no telemetry, no eval of untrusted input
+- [ ] Scripts are idempotent (safe to run multiple times)
+- [ ] Hardening scripts prompt before changes (non-destructive by default)
+
+## NIST Citation
+
+<!-- Link or reference to NIST SP 800-53 Rev 5 if applicable -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  # ── Lightweight tests that need only jq + the repo ──────────────────
+  catalog-tests:
+    name: Catalog platform-field tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run catalog-platform-field
+        run: bash tests/integration/catalog-platform-field.sh
+
+  # ── Docker-based integration tests ──────────────────────────────────
+  integration-tests:
+    name: Integration tests (Docker)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build sarge-hardened image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.hardened
+          tags: sarge-hardened:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run report-validation
+        run: |
+          docker run --rm \
+            sarge-hardened:ci \
+            bash -lc 'cd /home/oscar/sarge && bash tests/integration/report-validation.sh'
+
+      - name: Run drift-detection
+        run: |
+          docker run --rm \
+            sarge-hardened:ci \
+            bash -lc 'cd /home/oscar/sarge && bash tests/integration/drift-detection.sh'
+
+      - name: Run agent-safety-checks
+        run: |
+          docker run --rm \
+            sarge-hardened:ci \
+            bash -lc 'cd /home/oscar/sarge && bash tests/integration/agent-safety-checks.sh'
+
+  # ── Build-only check for the QA (unhardened) image ──────────────────
+  qa-image-build:
+    name: Build QA image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build sarge-qa image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.qa
+          tags: sarge-qa:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Integration tests (Docker)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build sarge-hardened image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.hardened
+          tags: sarge-hardened:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run catalog-platform-field
+        run: bash tests/integration/catalog-platform-field.sh
+
+      - name: Run report-validation
+        run: |
+          docker run --rm \
+            sarge-hardened:ci \
+            bash -lc 'cd /home/oscar/sarge && bash tests/integration/report-validation.sh'
+
+      - name: Run drift-detection
+        run: |
+          docker run --rm \
+            sarge-hardened:ci \
+            bash -lc 'cd /home/oscar/sarge && bash tests/integration/drift-detection.sh'
+
+      - name: Run agent-safety-checks
+        run: |
+          docker run --rm \
+            sarge-hardened:ci \
+            bash -lc 'cd /home/oscar/sarge && bash tests/integration/agent-safety-checks.sh'
+
+  release:
+    name: Create GitHub Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract tag
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog from commits
+        id: changelog
+        run: |
+          # Find the previous tag
+          PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n '2p')
+          if [ -z "$PREV_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+
+          {
+            echo 'body<<CHANGELOG_EOF'
+            echo "## What's Changed"
+            echo ""
+            git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges
+            echo ""
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-initial}...${{ steps.tag.outputs.version }}"
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.version }}
+          name: Sarge ${{ steps.tag.outputs.version }}
+          body: ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: ${{ contains(steps.tag.outputs.version, '-') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Sarge
 
-Thank you for your interest in improving Sarge. This document defines how the community proposes, reviews, and merges changes to the NIST 800-53 baseline and associated tooling.
+Thank you for your interest in improving Sarge. This document covers how to set up your environment, write changes, test them, and submit a PR.
 
 ---
 
@@ -14,25 +14,26 @@ By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md
 
 Sarge is maintained by Oscar Six Security LLC. The project maintainers are:
 
-- **Randy Hinders** ([@rhinders](https://github.com/rhinders)) — Product Owner, final decision authority
-- **Oscar** — Community AI agent (triage and first-response)
+- **Randy Hinders** ([@rhinders](https://github.com/rhinders)) -- Product Owner, final decision authority
+- **John Fay** ([@keonik](https://github.com/keonik)) -- Co-owner, active contributor
+- **Oscar** -- Community AI agent (triage and first-response)
 
 ---
 
 ## What We Accept
 
-### ✅ Welcome
+### Welcome
 - Bug fixes in assessment scripts (false positives, false negatives)
 - Corrections to 800-53 control mappings (with citation to NIST SP 800-53 Rev 5)
-- New check scripts for controls in scope (AC, AU, CM, IA full; SC/SI partial)
+- New check scripts for controls in scope (AC, AU, CM, IA, SC, SI, CP, CA, SA, MP, SR, RA, AS)
 - Documentation improvements
-- Platform compatibility fixes (Ubuntu 22.04/24.04, x86_64/arm64)
+- Platform compatibility fixes (Ubuntu 22.04/24.04/26.04, macOS, Windows)
 - Idempotency improvements to hardening scripts
+- New integration tests
 
-### ❌ Not Accepted (v1.0)
+### Not Accepted (v1.0)
 - Support for non-OpenClaw systems
 - RHEL/CentOS/non-Ubuntu Linux (deferred to v1.1)
-- Windows/WSL support (deferred)
 - Automated remediation in assessment scripts
 - GUI or web interface
 - External API calls or telemetry of any kind
@@ -41,9 +42,255 @@ Sarge is maintained by Oscar Six Security LLC. The project maintainers are:
 
 ---
 
+## Development Setup
+
+### Prerequisites
+
+- Ubuntu 22.04, 24.04, or 26.04 LTS (primary platform)
+- Bash 5+
+- An OpenClaw installation (for agent-scoped checks), or pass `--host-only` to skip those
+- Docker (optional, for container-based testing)
+
+### Clone and verify
+
+```bash
+git clone https://github.com/oscarsixsecllc/sarge.git
+cd sarge
+
+# Verify script integrity
+sha256sum -c CHECKSUMS.sha256
+
+# Run a gap analysis (read-only, no sudo)
+./assessment/assess.sh
+
+# Reports land in ~/.sarge/reports/
+```
+
+### Docker test images
+
+Two Dockerfiles are provided at the repo root:
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile.qa` | Bare Ubuntu 26.04 with unnecessary services pre-installed (cups, avahi). No OpenClaw, no Sarge deps. Use as a negative-test target to verify Sarge finds real failures. |
+| `Dockerfile.hardened` | Ubuntu 26.04 + Node 22 + OpenClaw + Sarge pre-copied + QA gateway config. CMD runs `assess.sh`. Use for full assess/harden roundtrip testing. |
+
+```bash
+# Build and run baseline (unhardened) -- expect many FAIL/WARN
+docker build -f Dockerfile.qa -t sarge-qa:latest .
+docker run --rm -it sarge-qa:latest bash -lc 'cd sarge && assessment/assess.sh'
+
+# Build and run hardened target -- expect improved PASS count
+docker build -f Dockerfile.hardened -t sarge-hardened:latest .
+docker run --rm sarge-hardened:latest
+```
+
+**Systemd caveat:** Default Docker containers have PID 1 = bash (no systemd), so 4 of 6 `harden-*.sh` modules will error at `systemctl is-system-running`. To exercise the full install/harden flow, either launch with systemd as PID 1 or use a real VM:
+
+```bash
+docker run --privileged --cgroupns=host \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run \
+  -e container=docker sarge-hardened:latest /sbin/init
+```
+
+---
+
+## Project Structure
+
+```
+sarge/
+├── assessment/
+│   ├── assess.sh                  # Main assessment runner (Linux/macOS)
+│   ├── assess.ps1                 # Assessment runner (Windows)
+│   ├── checks/                    # Per-family check scripts
+│   │   ├── check-ac.sh            # Access Control checks
+│   │   ├── check-au.sh            # Audit checks
+│   │   ├── check-as.sh            # Agent Safety overlay checks
+│   │   ├── check-cm.sh            # Configuration Management checks
+│   │   ├── check-*.ps1            # Windows equivalents
+│   │   └── ...
+│   ├── findings-catalog.json      # Per-finding rationale, remediation, expected values
+│   ├── probes/                    # Platform-specific data acquisition
+│   └── report/                    # Report generation (JSON + Markdown)
+├── baseline/
+│   ├── controls.json              # Machine-readable 800-53 control definitions
+│   ├── controls.md                # Human-readable control mapping
+│   └── openclaw.json.baseline     # Reference OpenClaw configuration baseline
+├── drift/
+│   ├── snapshot.sh                # Capture system state baseline
+│   ├── compare.sh                 # Compare current state against snapshot
+│   └── drift-cron.sh              # Cron-friendly wrapper for compare.sh
+├── scripts/
+│   ├── install.sh                 # Interactive hardening installer
+│   ├── harden-*.sh                # Individual hardening modules
+│   ├── backup-ubuntu.sh           # Pre-hardening backup (Ubuntu)
+│   ├── rollback-ubuntu.sh         # Rollback (Ubuntu)
+│   └── ...
+├── lib/
+│   ├── platform.sh                # Platform abstraction layer (Linux/macOS)
+│   ├── platform.ps1               # Platform abstraction (Windows)
+│   ├── platforms/                  # Per-OS probe implementations
+│   └── probes/                    # Reusable data acquisition probes
+├── tests/
+│   ├── integration/               # Bash integration test scripts
+│   └── Pester/                    # Windows Pester tests
+├── docs/                          # Quickstart and reference docs
+├── Dockerfile.qa                  # Unhardened test target
+├── Dockerfile.hardened            # Hardened test target
+├── CHECKSUMS.sha256               # Script integrity verification
+└── SKILL.md                       # OpenClaw skill definition
+```
+
+---
+
+## How Checks Work
+
+Each NIST 800-53 family has a check script under `assessment/checks/` (e.g., `check-ac.sh` for Access Control). The check scripts:
+
+1. Use `platform` helper functions from `lib/platform.sh` for OS-specific data acquisition
+2. Emit verdicts via helper functions: `passx`, `failx`, `warnx`, `skipx`
+3. Each verdict takes a **check ID** (e.g., `AC-2-empty-password`) and a description
+4. Check IDs must be stable once published (never rename without a migration note)
+5. Agent-scoped checks (OpenClaw-specific) are gated behind `SARGE_HOST_ONLY` so `--host-only` mode skips them
+
+The `assessment/findings-catalog.json` maps each check ID to:
+- `family`: NIST 800-53 control name
+- `what`: Short description of the observed condition
+- `expected`: What the correct state should be
+- `why`: Security risk explanation with NIST reference
+- `fix`: Remediation command or action (can be per-platform)
+- `scope`: `"host"` or `"agent"`
+
+---
+
+## Adding a New Control
+
+### 1. Add the check logic
+
+Edit the appropriate family check script under `assessment/checks/`. For example, to add an AC-19 check, edit `check-ac.sh`:
+
+```bash
+# AC-19: Access Control for Mobile Devices
+log "AC-19: Access Control for Mobile Devices"
+MOBILE_RESULT=$(platform some_probe_function)
+if [[ "$MOBILE_RESULT" == "expected" ]]; then
+  passx "AC-19-mobile-policy" "AC-19: Mobile device policy enforced"
+else
+  failx "AC-19-mobile-policy" "AC-19: Mobile device policy not enforced — $MOBILE_RESULT"
+fi
+```
+
+### 2. Add the finding to the catalog
+
+Add an entry to `assessment/findings-catalog.json` for each FAIL/WARN check ID:
+
+```json
+"AC-19-mobile-policy": {
+  "family": "AC-19 -- Access Control for Mobile Devices",
+  "what": "No mobile device management policy detected",
+  "expected": "Mobile device access policy enforced via MDM or equivalent",
+  "why": "NIST 800-53 AC-19 requires organizations to establish usage restrictions and implementation guidance for mobile devices. Without enforcement, mobile devices connecting to OpenClaw infrastructure may bypass access controls.",
+  "fix": "Configure mobile device management or restrict OpenClaw access to managed endpoints only."
+}
+```
+
+### 3. Add the control to controls.json
+
+Update `baseline/controls.json` with the new control definition, including the control ID, name, family, and implementation details.
+
+### 4. Add drift tracking (if applicable)
+
+If the new control checks something that can drift (config value, file permission, service state), make sure `drift/snapshot.sh` captures it and `drift/compare.sh` detects changes.
+
+### 5. Add platform probes (if needed)
+
+If the check needs OS-specific data acquisition, add a function to the appropriate platform file under `lib/platforms/`. The check script calls it via `platform <function_name>`.
+
+### 6. Write tests
+
+Add test coverage in the appropriate integration test under `tests/integration/`. At minimum, verify the check emits the expected verdict on known-good and known-bad states.
+
+---
+
+## Running Tests
+
+### Integration tests (Linux/macOS)
+
+All integration tests are self-contained bash scripts under `tests/integration/`:
+
+```bash
+# Report structure validation (runs assessment, validates JSON/MD output)
+bash tests/integration/report-validation.sh
+
+# Catalog-platform-field validation
+bash tests/integration/catalog-platform-field.sh
+
+# Drift detection pipeline (snapshot, compare, detect changes)
+bash tests/integration/drift-detection.sh
+
+# Agent-safety checks (Tier 1 workspace ACL / audit / rollback / tool-gate)
+bash tests/integration/agent-safety-checks.sh
+
+# Hardening round-trip (assess, harden, reassess, verify improvement)
+# Requires sudo and systemd (or iptables/NET_ADMIN); skips in containers
+bash tests/integration/hardening-roundtrip.sh
+
+# Host-only mode validation
+bash tests/integration/host-only-mode.sh
+
+# Backup smoke tests
+bash tests/integration/backup-ubuntu-smoke.sh
+bash tests/integration/backup-macos-smoke.sh
+```
+
+### Windows (Pester)
+
+```powershell
+Invoke-Pester -Path tests/Pester
+```
+
+### What to run before submitting a PR
+
+At minimum, run these on your target platform:
+
+1. `report-validation.sh` (verifies assessment output structure)
+2. `catalog-platform-field.sh` (verifies findings catalog consistency)
+3. `agent-safety-checks.sh` (if you touched agent-scoped checks)
+4. `drift-detection.sh` (if you touched drift-related code)
+
+---
+
+## Code Style and Conventions
+
+### Bash scripts
+
+- Use `#!/usr/bin/env bash` shebang
+- POSIX-compatible tools only (bash, awk, grep, sed, systemctl, etc.)
+- No external network calls, no telemetry, no eval of untrusted input
+- Scripts must be idempotent (safe to run multiple times)
+- Assessment scripts must be read-only (no system modifications)
+- Hardening scripts must prompt before making changes (non-destructive by default)
+- Include comments explaining WHAT the check does and WHY it matters for 800-53
+- Check IDs use the format `<FAMILY>-<NUMBER>-<short-slug>` (e.g., `AC-3-secrets-perm`)
+
+### Check ID naming
+
+- Family + control number are uppercase: `AC-3`, `CM-7`, `SI-4`
+- Slug is lowercase-kebab: `secrets-perm`, `cups-running`, `pwquality-minlen`
+- Full example: `AC-3-secrets-perm`, `CM-7-cups-running`, `IA-5-pwquality-minlen`
+- IDs are stable. Once published, never rename without a migration note.
+
+### Findings catalog
+
+- Every `failx` and `warnx` callsite in `check-*.sh` must have a corresponding entry in `findings-catalog.json`
+- PASS/SKIP verdicts do not need catalog entries
+- The `fix` field can be a string or a per-platform map: `{"default": "...", "macos": "...", "ubuntu": "..."}`
+
+---
+
 ## How to Propose a Change
 
-### Step 1: Open an Issue First
+### Step 1: Open an issue first
 
 Before writing code, open an issue describing:
 - What control or script is affected
@@ -53,65 +300,30 @@ Before writing code, open an issue describing:
 
 **Exception:** Typo/documentation fixes may go straight to a PR.
 
-### Step 2: Fork and Branch
+### Step 2: Fork and branch
 
 ```bash
-git fork https://github.com/oscarsixsecurity/sarge.git
+git clone https://github.com/oscarsixsecllc/sarge.git
+cd sarge
 git checkout -b fix/AC-2-check-false-positive
 ```
 
 Branch naming convention:
-- `fix/<control-id>-<short-description>` — bug fixes
-- `feat/<area>-<short-description>` — new features
-- `docs/<topic>` — documentation only
+- `fix/<control-id>-<short-description>` for bug fixes
+- `feat/<area>-<short-description>` for new features
+- `docs/<topic>` for documentation only
 
-### Step 3: Write Your Change
+### Step 3: Write and test your change
 
-**All scripts must:**
-- Be idempotent (safe to run multiple times without side effects)
-- Be non-destructive by default (read-only analysis preferred; changes require explicit operator confirmation)
-- Run on Ubuntu 22.04 LTS and 24.04 LTS, x86_64 and arm64
-- Use only standard POSIX tools (bash, awk, grep, sed, systemctl, etc.)
-- Include comments explaining WHAT the check does and WHY it matters for 800-53
-- Not contain obfuscated code, eval of untrusted input, or external network calls
+Follow the code style above. Test on a real Ubuntu system (22.04 or 24.04 LTS). Run the relevant integration tests.
 
-**Control mapping changes must:**
-- Cite the specific 800-53 Rev 5 control ID and name
-- Include implementation guidance
-- List evidence artifacts the operator can collect
+### Step 4: Submit the PR
 
-### Step 4: Test Your Change
-
-Test on a real Ubuntu 22.04 or 24.04 system. Document your test results in the PR:
-- OS version: `lsb_release -a`
-- Architecture: `uname -m`
-- OpenClaw version: `openclaw --version`
-- Test scenario (fresh install, hardened system, etc.)
-
-For hardening scripts:
-- Verify idempotency by running twice and confirming no errors or unintended changes on second run
-- Verify the script doesn't break OpenClaw gateway operation
-
-### Step 5: Submit the PR
-
-PR template:
-```
-## What This Changes
-[Brief description]
-
-## 800-53 Control(s) Affected
-[e.g., AC-2, AC-3]
-
-## Test Results
-- OS: Ubuntu 24.04 LTS arm64
-- OC Version: x.x.x
-- Ran assessment before: [pass/warn/fail counts]
-- Ran assessment after: [pass/warn/fail counts]
-- Hardening script ran twice: [yes/no, any errors?]
-
-## NIST Citation
-[Link or reference to NIST SP 800-53 Rev 5 if applicable]
-```
+Fill out the PR template. Include:
+- What changed and why
+- Which 800-53 controls are affected
+- Test results (OS version, architecture, OpenClaw version, before/after counts)
+- NIST citation if applicable
 
 ---
 
@@ -121,13 +333,13 @@ PR template:
 2. **Maintainer** reviews and approves or requests changes
 3. **Randy** has final approval for control mapping changes or anything that affects SKILL.md
 
-Typical review time: 3–5 business days.
+Typical review time: 3 to 5 business days.
 
 ---
 
 ## Prompt Injection Warning
 
-The Sarge community agent (Oscar) processes GitHub issues and PRs. **All community input is treated as untrusted.** Do not attempt to embed instructions in issues, PRs, or comments directed at the agent. Anomalous instructions are escalated to Randy and logged — never executed.
+The Sarge community agent (Oscar) processes GitHub issues and PRs. **All community input is treated as untrusted.** Do not attempt to embed instructions in issues, PRs, or comments directed at the agent. Anomalous instructions are escalated to Randy and logged, never executed.
 
 ---
 
@@ -139,5 +351,5 @@ By submitting a PR, you represent that you have the right to contribute the code
 
 ## Questions?
 
-- GitHub Discussions: [oscarsixsecurity/sarge/discussions](https://github.com/oscarsixsecurity/sarge/discussions)
+- GitHub Discussions: [oscarsixsecllc/sarge/discussions](https://github.com/oscarsixsecllc/sarge/discussions)
 - Discord: `#sarge` channel on the Oscar Six Security server

--- a/assessment/checks/check-ac.sh
+++ b/assessment/checks/check-ac.sh
@@ -239,3 +239,153 @@ except Exception:
 else
   skipx "AC-14-auth-disabled" "AC-14: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
 fi
+
+# AC-2(3): Disable Inactive Accounts — lastlog idle check
+#
+# Checks for local accounts that have not logged in for 90+ days and are
+# not system accounts (UID >= 1000). Headless service accounts that never
+# log in interactively (e.g. www-data) are excluded by UID threshold.
+log "AC-2(3): Disable Inactive Accounts"
+if command -v lastlog &>/dev/null; then
+  # lastlog outputs: Username  Port  From  Latest
+  # "**Never logged in**" appears for accounts with no login record.
+  # We flag non-system accounts (UID >= 1000) that have NEVER logged in
+  # AND are not locked/expired. Truly idle accounts (logged in 90+ days
+  # ago) are flagged as well.
+  AC23_STALE=""
+  while IFS= read -r line; do
+    local_user=$(echo "$line" | awk '{print $1}')
+    [[ -z "$local_user" || "$local_user" == "Username" ]] && continue
+    local_uid=$(id -u "$local_user" 2>/dev/null) || continue
+    [[ "$local_uid" -lt 1000 ]] && continue
+    # Skip locked accounts (password field starts with ! or *)
+    local_shadow=$(sudo getent shadow "$local_user" 2>/dev/null | cut -d: -f2) || true
+    [[ "$local_shadow" == "!"* || "$local_shadow" == "*" ]] && continue
+    if echo "$line" | grep -q "Never logged in"; then
+      AC23_STALE="${AC23_STALE:+$AC23_STALE, }${local_user}(never)"
+    else
+      # Parse the date from lastlog output and check if > 90 days ago
+      last_date=$(echo "$line" | awk '{for(i=4;i<=NF;i++) printf "%s ", $i; print ""}' | sed 's/ *$//')
+      if [[ -n "$last_date" ]]; then
+        last_epoch=$(date -d "$last_date" +%s 2>/dev/null) || continue
+        now_epoch=$(date +%s)
+        days_ago=$(( (now_epoch - last_epoch) / 86400 ))
+        if [[ "$days_ago" -ge 90 ]]; then
+          AC23_STALE="${AC23_STALE:+$AC23_STALE, }${local_user}(${days_ago}d)"
+        fi
+      fi
+    fi
+  done < <(lastlog 2>/dev/null)
+  if [[ -z "$AC23_STALE" ]]; then
+    passx "AC-2-3-inactive-accounts" "AC-2(3): No inactive local accounts (>90 days) found"
+  else
+    warnx "AC-2-3-inactive-accounts" "AC-2(3): Inactive accounts found: $AC23_STALE — review and disable or remove"
+  fi
+else
+  skipx "AC-2-3-inactive-accounts" "AC-2(3): lastlog command not available — cannot check account activity"
+fi
+
+# AC-20: Use of External Systems — MCP servers and plugins pointing to external endpoints
+#
+# Enumerates configured MCP servers and plugin entries in openclaw.json
+# that reference external URLs/hosts. Informational: always PASS with
+# a summary so operators can reconcile against their approved-external-
+# systems list (mirrors the CM-8 / SA-9 approach).
+log "AC-20: Use of External Systems"
+AC20_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    AC20_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$AC20_OC_CONFIG" ]]; then
+  AC20_CONFIG_NAME=$(basename "$AC20_OC_CONFIG")
+  AC20_EXTERNAL_COUNT="unknown"
+  if command -v python3 &>/dev/null; then
+    AC20_EXTERNAL_COUNT=$(python3 -c '
+import json, sys, re
+try:
+    with open(sys.argv[1]) as fh:
+        cfg = json.load(fh)
+    count = 0
+    # MCP servers with external URLs or non-local commands
+    servers = (cfg.get("mcp") or {}).get("servers") or {}
+    for name, srv in servers.items():
+        if name.startswith("_"):
+            continue
+        url = (srv.get("url") or srv.get("command") or "")
+        if re.search(r"https?://", str(url)):
+            count += 1
+    # Plugin entries with external URLs
+    plugins = (cfg.get("plugins") or {}).get("entries") or cfg.get("plugins") or {}
+    if isinstance(plugins, dict):
+        for name, plg in plugins.items():
+            url = str(plg) if isinstance(plg, str) else (plg.get("url") or "")
+            if re.search(r"https?://", url):
+                count += 1
+    print(count)
+except Exception:
+    print("unknown")
+' "$AC20_OC_CONFIG" 2>/dev/null)
+  fi
+  passx "AC-20-external-systems" "AC-20: ${AC20_EXTERNAL_COUNT} external MCP server(s)/plugin(s) detected in $AC20_CONFIG_NAME — reconcile against approved external systems list"
+else
+  skipx "AC-20-external-systems" "AC-20: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi
+
+# AC-22: Publicly Accessible Content — web interface and exposed endpoints
+#
+# Checks whether the OpenClaw web UI is enabled and whether any HTTP
+# endpoints are configured for public access. A running web interface
+# means the host serves content that may be reachable from the network.
+log "AC-22: Publicly Accessible Content"
+AC22_OC_CONFIG=""
+for candidate in "$HOME/.openclaw/openclaw.json" "$HOME/.openclaw/config.json"; do
+  if [[ -f "$candidate" ]]; then
+    AC22_OC_CONFIG="$candidate"
+    break
+  fi
+done
+if [[ -n "$AC22_OC_CONFIG" ]]; then
+  AC22_CONFIG_NAME=$(basename "$AC22_OC_CONFIG")
+  AC22_WEB_ENABLED=""
+  AC22_HTTP_ENDPOINTS=""
+  if command -v python3 &>/dev/null; then
+    AC22_WEB_ENABLED=$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        cfg = json.load(fh)
+    web = (cfg.get("web") or {}).get("enabled")
+    print(str(web).lower() if web is not None else "unset")
+except Exception:
+    print("unknown")
+' "$AC22_OC_CONFIG" 2>/dev/null)
+    AC22_HTTP_ENDPOINTS=$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        cfg = json.load(fh)
+    endpoints = ((cfg.get("gateway") or {}).get("http") or {}).get("endpoints") or {}
+    enabled = [k for k, v in endpoints.items() if isinstance(v, dict) and v.get("enabled") in [True, "true"]]
+    print(",".join(enabled) if enabled else "none")
+except Exception:
+    print("unknown")
+' "$AC22_OC_CONFIG" 2>/dev/null)
+  fi
+  if [[ "$AC22_WEB_ENABLED" == "true" ]]; then
+    warnx "AC-22-public-content" "AC-22: web.enabled is true in $AC22_CONFIG_NAME — verify public-facing content is authorized and reviewed"
+  elif [[ "$AC22_WEB_ENABLED" == "false" ]]; then
+    passx "AC-22-public-content" "AC-22: web.enabled is false in $AC22_CONFIG_NAME"
+  else
+    passx "AC-22-public-content" "AC-22: web.enabled is ${AC22_WEB_ENABLED:-unset} in $AC22_CONFIG_NAME — no explicit public web content"
+  fi
+  if [[ -n "$AC22_HTTP_ENDPOINTS" && "$AC22_HTTP_ENDPOINTS" != "none" && "$AC22_HTTP_ENDPOINTS" != "unknown" ]]; then
+    warnx "AC-22-http-endpoints" "AC-22: HTTP endpoints enabled in $AC22_CONFIG_NAME: $AC22_HTTP_ENDPOINTS — ensure each is intentionally exposed"
+  else
+    passx "AC-22-http-endpoints" "AC-22: No HTTP endpoints enabled in $AC22_CONFIG_NAME"
+  fi
+else
+  skipx "AC-22-public-content" "AC-22: OpenClaw config not found at ~/.openclaw/openclaw.json (or legacy ~/.openclaw/config.json)"
+fi

--- a/assessment/checks/check-cm.sh
+++ b/assessment/checks/check-cm.sh
@@ -222,3 +222,86 @@ if command -v npm &>/dev/null; then
 else
   skipx "CM-11-global-npm-packages" "CM-11: npm not found on PATH — global package inventory check skipped"
 fi
+
+# CM-10: Software Usage Restrictions — license/allowlist check
+#
+# Checks whether a Sarge software-allowlist file exists and whether
+# installed packages contain any known restrictively-licensed software.
+# This is a lightweight signal: a full license audit requires a dedicated
+# tool (e.g. license_finder, fossa). Sarge flags the absence of a policy
+# file and spots common non-permissive indicators in dpkg descriptions.
+log "CM-10: Software Usage Restrictions"
+CM10_ALLOWLIST="${SARGE_DIR}/baseline/software-allowlist.txt"
+if [[ -f "$CM10_ALLOWLIST" ]]; then
+  passx "CM-10-allowlist-present" "CM-10: Software allowlist is present at $CM10_ALLOWLIST"
+  # Cross-check: are there installed packages NOT on the allowlist?
+  if command -v dpkg &>/dev/null; then
+    CM10_INSTALLED=$(dpkg --get-selections 2>/dev/null | awk '/\tinstall$/{print $1}')
+    CM10_UNLISTED=""
+    CM10_COUNT=0
+    while IFS= read -r pkg; do
+      [[ -z "$pkg" ]] && continue
+      if ! grep -qxF "$pkg" "$CM10_ALLOWLIST" 2>/dev/null; then
+        CM10_COUNT=$((CM10_COUNT + 1))
+        if [[ $CM10_COUNT -le 5 ]]; then
+          CM10_UNLISTED="${CM10_UNLISTED:+$CM10_UNLISTED, }${pkg}"
+        fi
+      fi
+    done <<< "$CM10_INSTALLED"
+    if [[ $CM10_COUNT -eq 0 ]]; then
+      passx "CM-10-unlisted-packages" "CM-10: All installed packages are on the software allowlist"
+    else
+      warnx "CM-10-unlisted-packages" "CM-10: ${CM10_COUNT} installed package(s) not on software allowlist — first 5: ${CM10_UNLISTED}"
+    fi
+  fi
+else
+  warnx "CM-10-allowlist-present" "CM-10: No software allowlist found at $CM10_ALLOWLIST — create one to enforce software usage restrictions"
+fi
+
+# CM-12: Information Location — data-at-rest location mapping
+#
+# Enumerates known data-storage locations for an OpenClaw deployment so
+# operators know where sensitive data lives. Informational: always PASS
+# with a summary of discovered locations (matches the CM-8 approach).
+log "CM-12: Information Location"
+CM12_LOCATIONS=""
+CM12_COUNT=0
+# OpenClaw workspace
+if [[ -d "$HOME/.openclaw" ]]; then
+  CM12_SIZE=$(du -sh "$HOME/.openclaw" 2>/dev/null | awk '{print $1}')
+  CM12_LOCATIONS="${CM12_LOCATIONS}~/.openclaw(${CM12_SIZE:-?})"
+  CM12_COUNT=$((CM12_COUNT + 1))
+fi
+# Sarge snapshots/runs
+SARGE_DATA_DIR="${SARGE_SNAPSHOT_DIR:-$HOME/.sarge}"
+if [[ -d "$SARGE_DATA_DIR" ]]; then
+  CM12_SARGE_SIZE=$(du -sh "$SARGE_DATA_DIR" 2>/dev/null | awk '{print $1}')
+  CM12_LOCATIONS="${CM12_LOCATIONS:+$CM12_LOCATIONS, }~/.sarge(${CM12_SARGE_SIZE:-?})"
+  CM12_COUNT=$((CM12_COUNT + 1))
+fi
+# Secrets directory
+if [[ -d "$HOME/.openclaw/secrets" ]]; then
+  CM12_SEC_COUNT=$(find "$HOME/.openclaw/secrets" -maxdepth 1 -type f 2>/dev/null | wc -l)
+  CM12_LOCATIONS="${CM12_LOCATIONS:+$CM12_LOCATIONS, }secrets(${CM12_SEC_COUNT} files)"
+fi
+# Media directory (if media.ttlHours is in play)
+MEDIA_DIR="$HOME/.openclaw/media"
+if [[ -d "$MEDIA_DIR" ]]; then
+  CM12_MEDIA_SIZE=$(du -sh "$MEDIA_DIR" 2>/dev/null | awk '{print $1}')
+  CM12_LOCATIONS="${CM12_LOCATIONS:+$CM12_LOCATIONS, }media(${CM12_MEDIA_SIZE:-?})"
+  CM12_COUNT=$((CM12_COUNT + 1))
+fi
+# Transcript/log directories
+for tdir in "$HOME/.openclaw/transcripts" "$HOME/.openclaw/logs"; do
+  if [[ -d "$tdir" ]]; then
+    tname=$(basename "$tdir")
+    tsize=$(du -sh "$tdir" 2>/dev/null | awk '{print $1}')
+    CM12_LOCATIONS="${CM12_LOCATIONS:+$CM12_LOCATIONS, }${tname}(${tsize:-?})"
+    CM12_COUNT=$((CM12_COUNT + 1))
+  fi
+done
+if [[ $CM12_COUNT -gt 0 ]]; then
+  passx "CM-12-data-locations" "CM-12: Data-at-rest locations: $CM12_LOCATIONS — verify each is backed up and access-controlled per policy"
+else
+  warnx "CM-12-data-locations" "CM-12: No standard OpenClaw data directories found — verify data storage locations"
+fi

--- a/assessment/findings-catalog.json
+++ b/assessment/findings-catalog.json
@@ -162,14 +162,14 @@
     "fix": "Restore baseline/openclaw.json.baseline from the sarge repo, or regenerate from a known-good host."
   },
   "CM-2-baseline-version-pin-missing": {
-    "family": "CM-2 — Baseline Configuration",
+    "family": "CM-2 \u2014 Baseline Configuration",
     "what": "Sarge baseline file is present but lacks the _openclawVersion schema-version pin",
     "expected": "baseline/openclaw.json.baseline includes a top-level _openclawVersion field naming the OpenClaw release the baseline was authored against",
     "why": "OpenClaw's config schema evolves; a baseline written against one release will silently misclassify fields when compared against a substantially different release. NIST 800-53 CM-2 requires baselines to be current and identifiable. The pin lets drift tooling refuse comparison (or warn) when the running OpenClaw is too far from the baseline's schema of record.",
     "fix": "Upgrade Sarge to a version that ships baseline/openclaw.json.baseline v0.6.0 or newer, or add the pin manually: \"_openclawVersion\": \"<running-version>\"."
   },
   "CM-2-baseline-version-drift": {
-    "family": "CM-2 — Baseline Configuration",
+    "family": "CM-2 \u2014 Baseline Configuration",
     "what": "Running OpenClaw version differs from the baseline's _openclawVersion pin by more than one minor release",
     "expected": "Baseline authored against the same major.minor as the running OpenClaw (patch-level drift is fine)",
     "why": "A baseline more than one minor behind the running OpenClaw is missing new config surfaces (new tools, new gateway options, new sandbox knobs). Drift comparisons will report false PASS for controls that reference config keys the baseline never knew existed. NIST 800-53 CM-2 requires the baseline to reflect the currently deployed configuration surface.",
@@ -1111,5 +1111,61 @@
     "expected": "All available security patches applied",
     "why": "Pending security patches represent known vulnerabilities with available fixes. Delaying application increases the window of exposure.",
     "fix": "sudo apt update && sudo apt upgrade -y"
+  },
+  "AC-2-3-inactive-accounts": {
+    "family": "AC-2(3) \u2014 Disable Inactive Accounts",
+    "what": "Local accounts that have not logged in for 90+ days or have never logged in",
+    "expected": "All non-system accounts are actively used or explicitly locked/disabled",
+    "why": "AC-2(3) requires disabling inactive accounts to reduce the attack surface. Dormant accounts are prime targets for credential stuffing and lateral movement.",
+    "fix": "Review each flagged account: lock it with \"usermod -L <user>\" if the owner is temporarily away, or delete with \"userdel <user>\" if no longer needed.",
+    "scope": "host"
+  },
+  "AC-20-external-systems": {
+    "family": "AC-20 \u2014 Use of External Systems",
+    "what": "MCP servers and plugins configured to connect to external URLs/hosts",
+    "expected": "All external system connections are documented and approved per organizational policy",
+    "why": "AC-20 requires establishing terms and conditions for using external information systems. Each external MCP server or plugin is a data-flow path that crosses the trust boundary.",
+    "fix": "Reconcile the reported external MCP servers and plugins against your approved external systems list. Remove or disable any that are not explicitly authorized.",
+    "scope": "agent"
+  },
+  "AC-22-public-content": {
+    "family": "AC-22 \u2014 Publicly Accessible Content",
+    "what": "The OpenClaw web interface is enabled, potentially serving public content",
+    "expected": "Public-facing content is authorized, reviewed, and does not include nonpublic information",
+    "why": "AC-22 requires designating individuals to review information prior to public posting. An enabled web interface may expose agent outputs, configuration details, or internal data.",
+    "fix": "Set web.enabled to false if the web UI should not be publicly accessible. If it must be enabled, ensure content review procedures are in place.",
+    "scope": "agent"
+  },
+  "AC-22-http-endpoints": {
+    "family": "AC-22 \u2014 Publicly Accessible Content",
+    "what": "HTTP API endpoints are enabled on the OpenClaw gateway",
+    "expected": "Only intentionally exposed endpoints are enabled, and access controls are in place",
+    "why": "AC-22 requires reviewing publicly accessible content. Enabled HTTP endpoints (chatCompletions, responses, etc.) may allow external access to agent capabilities.",
+    "fix": "Review each enabled endpoint in gateway.http.endpoints and disable any that are not required for your use case.",
+    "scope": "agent"
+  },
+  "CM-10-allowlist-present": {
+    "family": "CM-10 \u2014 Software Usage Restrictions",
+    "what": "No software allowlist file exists to enforce approved package policies",
+    "expected": "A software-allowlist.txt is maintained listing all approved packages for the host",
+    "why": "CM-10 requires establishing software usage restrictions. Without an allowlist, there is no baseline to detect unauthorized software installations.",
+    "fix": "Create baseline/software-allowlist.txt with one package name per line. Populate it with the output of \"dpkg --get-selections | awk ''/install/{print }'\" after reviewing the current package set.",
+    "scope": "host"
+  },
+  "CM-10-unlisted-packages": {
+    "family": "CM-10 \u2014 Software Usage Restrictions",
+    "what": "Installed packages are not listed on the software allowlist",
+    "expected": "All installed packages appear on the approved software allowlist",
+    "why": "CM-10 requires controlling software usage. Packages not on the allowlist may introduce unapproved functionality, dependencies, or vulnerabilities.",
+    "fix": "Review each unlisted package: add it to baseline/software-allowlist.txt if approved, or remove it with \"apt remove <package>\" if not.",
+    "scope": "host"
+  },
+  "CM-12-data-locations": {
+    "family": "CM-12 \u2014 Information Location",
+    "what": "Data-at-rest locations for the OpenClaw deployment have been enumerated",
+    "expected": "Each data location is backed up, access-controlled, and documented in the system security plan",
+    "why": "CM-12 requires identifying the location of information and the specific system components on which it is processed and stored. Knowing where data lives is prerequisite for backup, incident response, and access control.",
+    "fix": "Compare the reported data locations against your backup schedule and access-control policies. Ensure each directory is covered.",
+    "scope": "agent"
   }
 }

--- a/baseline/controls.json
+++ b/baseline/controls.json
@@ -1,7 +1,7 @@
 {
   "version": "NIST SP 800-53 Rev 5",
-  "generated": "2026-09-01",
-  "baselineVersion": "0.6.0",
+  "generated": "2026-09-04",
+  "baselineVersion": "0.7.0",
   "openclawVersion": "2026.7.1-2",
   "publisher": "Oscar Six Security LLC",
   "scope": "OpenClaw deployments on Ubuntu 22.04/24.04 LTS",
@@ -22,6 +22,18 @@
         "who"
       ],
       "remediation": "Remove unused accounts. Restrict OpenClaw allowlist to named users only."
+    },
+    {
+      "id": "AC-2(3)",
+      "family": "AC",
+      "name": "Disable Inactive Accounts",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "lastlog",
+        "getent shadow"
+      ],
+      "remediation": "Review accounts inactive for 90+ days and disable or remove them. Use usermod -L to lock or userdel to remove."
     },
     {
       "id": "AC-3",
@@ -57,6 +69,36 @@
       "remediation": "Set workspaceOnly=true. Set sandbox mode to all. Restrict sudoers. Disable browser noSandbox. Set hooks.allowRequestSessionKey=false."
     },
     {
+      "id": "AC-4",
+      "family": "AC",
+      "name": "Information Flow Enforcement",
+      "status": "full",
+      "openclaw_settings": [
+        "session.dmScope",
+        "messages.groupChat.visibleReplies",
+        "tools.web.search.enabled",
+        "tools.web.fetch.enabled",
+        "diagnostics.otel.captureContent.enabled",
+        "broadcast.strategy",
+        "acp.stream.maxOutputChars",
+        "surfaces.*.silentReply"
+      ],
+      "os_checks": [],
+      "remediation": "Set session.dmScope to per-channel-peer. Review tools.web settings. Disable diagnostics.otel.captureContent unless the collector is within your data boundary."
+    },
+    {
+      "id": "AC-5",
+      "family": "AC",
+      "name": "Separation of Duties",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "whoami",
+        "groups <user>"
+      ],
+      "remediation": "Run OpenClaw under a dedicated service account that is not a member of the sudo/admin group."
+    },
+    {
       "id": "AC-6",
       "family": "AC",
       "name": "Least Privilege",
@@ -73,6 +115,81 @@
         "groups <user>"
       ],
       "remediation": "Disable elevated exec unless required. Confirm service account has no unnecessary group memberships. Set agents.defaults.subagents.allowChildOverrides=false. Disable gateway terminal."
+    },
+    {
+      "id": "AC-7",
+      "family": "AC",
+      "name": "Unsuccessful Logon Attempts",
+      "status": "full",
+      "openclaw_settings": [
+        "gateway.auth.rateLimit.maxAttempts",
+        "gateway.auth.rateLimit.windowMs",
+        "gateway.auth.rateLimit.lockoutMs",
+        "auth.cooldowns"
+      ],
+      "os_checks": [
+        "pam_faillock status"
+      ],
+      "remediation": "Configure gateway.auth.rateLimit with maxAttempts=10, windowMs=60000, lockoutMs=300000. Configure PAM faillock."
+    },
+    {
+      "id": "AC-8",
+      "family": "AC",
+      "name": "System Use Notification",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "grep ^Banner /etc/ssh/sshd_config"
+      ],
+      "remediation": "Set a Banner directive in sshd_config pointing to a system-use notification file."
+    },
+    {
+      "id": "AC-10",
+      "family": "AC",
+      "name": "Concurrent Session Control",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": [
+        "grep maxlogins /etc/security/limits.conf"
+      ],
+      "remediation": "Set a maxlogins limit in /etc/security/limits.conf to bound concurrent sessions per user."
+    },
+    {
+      "id": "AC-11",
+      "family": "AC",
+      "name": "Device Lock",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "grep TMOUT /etc/profile /etc/profile.d/*"
+      ],
+      "remediation": "Set TMOUT in /etc/profile or /etc/profile.d/ to auto-lock idle shell sessions."
+    },
+    {
+      "id": "AC-12",
+      "family": "AC",
+      "name": "Session Termination",
+      "status": "full",
+      "openclaw_settings": [
+        "mcp.sessionIdleTtlMs",
+        "agents.defaults.subagents.archiveAfterMinutes",
+        "cron.sessionRetention",
+        "acp.runtime.ttlMinutes",
+        "crestodian.rescue.pendingTtlMinutes"
+      ],
+      "os_checks": [],
+      "remediation": "Set mcp.sessionIdleTtlMs to 600000 (10 min). Set subagents.archiveAfterMinutes to 60. Review cron.sessionRetention."
+    },
+    {
+      "id": "AC-14",
+      "family": "AC",
+      "name": "Permitted Actions Without Identification or Authentication",
+      "status": "full",
+      "openclaw_settings": [
+        "auth.enabled"
+      ],
+      "os_checks": [],
+      "remediation": "Set auth.enabled to true in openclaw.json so gateway actions require identification/authentication."
     },
     {
       "id": "AC-17",
@@ -92,6 +209,30 @@
         "ss -tlnp"
       ],
       "remediation": "Set gateway.bind to loopback. Enable gateway.auth.mode=token. Set auth rateLimit. Disable external hooks and gateway terminal."
+    },
+    {
+      "id": "AC-20",
+      "family": "AC",
+      "name": "Use of External Systems",
+      "status": "full",
+      "openclaw_settings": [
+        "mcp.servers",
+        "plugins.entries"
+      ],
+      "os_checks": [],
+      "remediation": "Review all external MCP servers and plugins against an approved external systems list. Remove any unauthorized external connections."
+    },
+    {
+      "id": "AC-22",
+      "family": "AC",
+      "name": "Publicly Accessible Content",
+      "status": "full",
+      "openclaw_settings": [
+        "web.enabled",
+        "gateway.http.endpoints"
+      ],
+      "os_checks": [],
+      "remediation": "Disable web.enabled if the web UI should not be public. Review each HTTP endpoint and disable any that are not intentionally exposed."
     },
     {
       "id": "AU-2",
@@ -124,6 +265,68 @@
       "remediation": "Ensure audit records include timestamp, user, action, and outcome."
     },
     {
+      "id": "AU-4",
+      "family": "AU",
+      "name": "Audit Log Storage Capacity",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "df -P /var/log/audit",
+        "df -P /var/log"
+      ],
+      "remediation": "Ensure the audit log partition retains at least 10% free space. Configure log rotation with adequate headroom or expand storage."
+    },
+    {
+      "id": "AU-5",
+      "family": "AU",
+      "name": "Response to Audit Processing Failures",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "grep disk_full_action /etc/audit/auditd.conf",
+        "grep admin_space_left_action /etc/audit/auditd.conf"
+      ],
+      "remediation": "Set disk_full_action and admin_space_left_action in auditd.conf to something other than IGNORE (e.g. SYSLOG, EMAIL, HALT)."
+    },
+    {
+      "id": "AU-6",
+      "family": "AU",
+      "name": "Audit Review, Analysis, and Reporting",
+      "status": "full",
+      "openclaw_settings": [
+        "security.audit.suppressions"
+      ],
+      "os_checks": [
+        "auditctl -l"
+      ],
+      "remediation": "Review security.audit.suppressions entries. Every suppression must be justified and periodically reviewed. Unreviewed suppressions create blind spots."
+    },
+    {
+      "id": "AU-7",
+      "family": "AU",
+      "name": "Audit Record Reduction and Report Generation",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "which journalctl",
+        "which ausearch",
+        "grep -r '@' /etc/rsyslog.d/"
+      ],
+      "remediation": "Install auditd (provides ausearch) or configure rsyslog forwarding so audit records can be queried and aggregated."
+    },
+    {
+      "id": "AU-8",
+      "family": "AU",
+      "name": "Time Stamps",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "timedatectl show -p NTPSynchronized",
+        "chronyc tracking"
+      ],
+      "remediation": "Enable NTP synchronization: sudo timedatectl set-ntp true."
+    },
+    {
       "id": "AU-9",
       "family": "AU",
       "name": "Protection of Audit Information",
@@ -138,6 +341,17 @@
         "stat /var/log/audit/audit.log"
       ],
       "remediation": "Audit logs must be owned by root, mode 600. Restrict write access."
+    },
+    {
+      "id": "AU-11",
+      "family": "AU",
+      "name": "Audit Record Retention",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "grep rotate /etc/logrotate.d/auditd"
+      ],
+      "remediation": "Configure logrotate for audit logs with a 'rotate' count of at least 4 (weekly rotation) to meet minimum retention."
     },
     {
       "id": "AU-12",
@@ -155,17 +369,33 @@
       "remediation": "Add auditd watch rules for ~/.openclaw/secrets/ and OpenClaw config files. Review transcripts.autoStart sources."
     },
     {
-      "id": "AU-6",
-      "family": "AU",
-      "name": "Audit Review, Analysis, and Reporting",
+      "id": "CA-7",
+      "family": "CA",
+      "name": "Continuous Monitoring",
       "status": "full",
       "openclaw_settings": [
-        "security.audit.suppressions"
+        "security.installPolicy.enabled",
+        "security.audit.suppressions",
+        "diagnostics.enabled"
       ],
       "os_checks": [
-        "auditctl -l"
+        "systemctl status auditd",
+        "unattended-upgrades --dry-run"
       ],
-      "remediation": "Review security.audit.suppressions entries. Every suppression must be justified and periodically reviewed. Unreviewed suppressions create blind spots."
+      "remediation": "Enable security.installPolicy. Review audit suppressions. Enable diagnostics."
+    },
+    {
+      "id": "CA-9",
+      "family": "CA",
+      "name": "Internal System Connections",
+      "status": "partial",
+      "openclaw_settings": [
+        "mcp.servers"
+      ],
+      "os_checks": [
+        "parse ~/.openclaw/openclaw.json mcp.servers"
+      ],
+      "remediation": "Document each MCP server connection in the system security plan / interconnection agreements. Remove any unused or unauthorized servers."
     },
     {
       "id": "CM-2",
@@ -180,6 +410,33 @@
         "systemctl list-units --state=enabled"
       ],
       "remediation": "Maintain openclaw.json.baseline as the documented configuration baseline."
+    },
+    {
+      "id": "CM-3",
+      "family": "CM",
+      "name": "Configuration Change Control",
+      "status": "full",
+      "openclaw_settings": [
+        "gateway.reload.mode",
+        "update.auto.enabled",
+        "commands.restart"
+      ],
+      "os_checks": [],
+      "remediation": "Set gateway.reload.mode to hybrid. Disable update.auto unless stableDelayHours >= 6. Review restart command availability."
+    },
+    {
+      "id": "CM-5",
+      "family": "CM",
+      "name": "Access Restrictions for Change",
+      "status": "full",
+      "openclaw_settings": [
+        "skills.workshop.approvalPolicy",
+        "skills.install.allowUploadedArchives",
+        "skills.workshop.allowSymlinkTargetWrites",
+        "plugins.entries"
+      ],
+      "os_checks": [],
+      "remediation": "Set skills.workshop.approvalPolicy to review. Disable allowUploadedArchives and allowSymlinkTargetWrites. Review plugin entries for hooks.allowPromptInjection."
     },
     {
       "id": "CM-6",
@@ -237,6 +494,79 @@
       "remediation": "Disable unused OpenClaw plugins, skills, and tools. Set skills.workshop.approvalPolicy=review. Disable browser unless needed. Set discovery.mdns.mode=minimal. Remove unnecessary OS packages."
     },
     {
+      "id": "CM-8",
+      "family": "CM",
+      "name": "System Component Inventory",
+      "status": "full",
+      "openclaw_settings": [
+        "mcp.servers",
+        "plugins.entries"
+      ],
+      "os_checks": [
+        "node --version"
+      ],
+      "remediation": "Maintain an approved component list and reconcile it against the reported Node.js version, MCP servers, and plugins."
+    },
+    {
+      "id": "CM-10",
+      "family": "CM",
+      "name": "Software Usage Restrictions",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": [
+        "dpkg --get-selections"
+      ],
+      "remediation": "Create a software-allowlist.txt in baseline/ listing approved packages. Review and remove any unlisted packages."
+    },
+    {
+      "id": "CM-11",
+      "family": "CM",
+      "name": "User-Installed Software",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": [
+        "npm list -g --depth=0"
+      ],
+      "remediation": "Review globally-installed npm packages and remove any that are not approved for the host."
+    },
+    {
+      "id": "CM-12",
+      "family": "CM",
+      "name": "Information Location",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "du -sh ~/.openclaw",
+        "du -sh ~/.sarge"
+      ],
+      "remediation": "Verify each reported data-at-rest location is backed up and access-controlled per organizational policy."
+    },
+    {
+      "id": "CP-9",
+      "family": "CP",
+      "name": "System Backup",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": [
+        "crontab -l | grep -i backup",
+        "systemctl list-timers --all | grep -i backup"
+      ],
+      "remediation": "Configure a scheduled backup (cron or systemd timer) of ~/.openclaw config, secrets, and workspace state. Verify backups are recoverable."
+    },
+    {
+      "id": "CP-10",
+      "family": "CP",
+      "name": "System Recovery and Reconstitution",
+      "status": "full",
+      "openclaw_settings": [
+        "crestodian.rescue.enabled",
+        "crestodian.rescue.ownerDmOnly",
+        "crestodian.rescue.pendingTtlMinutes"
+      ],
+      "os_checks": [],
+      "remediation": "If rescue mode is enabled, restrict to ownerDmOnly=true. Set pendingTtlMinutes to a short window (5 min default) to prevent stale rescue state."
+    },
+    {
       "id": "IA-2",
       "family": "IA",
       "name": "Identification and Authentication (Org Users)",
@@ -249,6 +579,17 @@
         "grep pam_faillock /etc/pam.d/common-auth"
       ],
       "remediation": "Enable PAM faillock. Restrict OpenClaw to authenticated Discord/channel users only."
+    },
+    {
+      "id": "IA-4",
+      "family": "IA",
+      "name": "Identifier Management",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "awk -F: '{print $3}' /etc/passwd | sort | uniq -d"
+      ],
+      "remediation": "Eliminate duplicate UIDs in /etc/passwd. Never reuse a UID after deleting an account."
     },
     {
       "id": "IA-5",
@@ -280,129 +621,117 @@
       "remediation": "Ensure login failure messages do not reveal whether username or password was wrong."
     },
     {
-      "id": "SC-8",
-      "family": "SC",
-      "name": "Transmission Confidentiality and Integrity",
+      "id": "IA-7",
+      "family": "IA",
+      "name": "Cryptographic Module Authentication",
       "status": "full",
       "openclaw_settings": [
-        "gateway.tls.enabled",
-        "gateway.controlUi.allowInsecureAuth",
+        "gateway.tls"
+      ],
+      "os_checks": [
+        "grep Protocol /etc/ssh/sshd_config",
+        "grep Ciphers /etc/ssh/sshd_config"
+      ],
+      "remediation": "Disable SSHv1 and weak ciphers (3DES, RC4/arcfour, CBC-mode) in sshd_config. Set gateway TLS minVersion to TLSv1.2 or higher."
+    },
+    {
+      "id": "IA-8",
+      "family": "IA",
+      "name": "Identification and Authentication (Non-Org Users)",
+      "status": "full",
+      "openclaw_settings": [
+        "auth.mode",
+        "auth.providers"
+      ],
+      "os_checks": [
+        "grep -o auth.mode/providers in openclaw.json"
+      ],
+      "remediation": "Set an explicit auth.mode and register auth.providers. Disable anonymous access so external channel users (Discord/Telegram/etc.) are identified before gateway trust."
+    },
+    {
+      "id": "IA-11",
+      "family": "IA",
+      "name": "Re-authentication",
+      "status": "full",
+      "openclaw_settings": [
+        "mcp.sessionIdleTtlMs"
+      ],
+      "os_checks": [
+        "grep sessionIdleTtlMs in openclaw.json"
+      ],
+      "remediation": "Set mcp.sessionIdleTtlMs to a finite, reasonable value (e.g. 24h or less) so idle sessions require re-authentication."
+    },
+    {
+      "id": "MP-6",
+      "family": "MP",
+      "name": "Media Sanitization",
+      "status": "partial",
+      "openclaw_settings": [
+        "media.ttlHours",
+        "media.maxSizeMb"
+      ],
+      "os_checks": [],
+      "remediation": "Set media.ttlHours to a positive retention window and media.maxSizeMb to bound stored media size in the OpenClaw config."
+    },
+    {
+      "id": "RA-5",
+      "family": "RA",
+      "name": "Vulnerability Monitoring and Scanning",
+      "status": "full",
+      "openclaw_settings": [],
+      "os_checks": [
+        "trivy/grype/oscap/lynis/debsecan",
+        "npm audit",
+        "apt list --upgradable"
+      ],
+      "remediation": "Install a vulnerability scanner (trivy or grype recommended). Run npm audit on OpenClaw dependencies. Apply pending OS security patches."
+    },
+    {
+      "id": "SA-9",
+      "family": "SA",
+      "name": "External System Services",
+      "status": "partial",
+      "openclaw_settings": [
         "mcp.servers"
       ],
-      "os_checks": [
-        "ss -tlnp",
-        "openssl s_client -connect localhost:18790"
-      ],
-      "remediation": "Enable TLS on gateway. Use Cloudflare Tunnel (TLS enforced) for all remote access."
+      "os_checks": [],
+      "remediation": "Review each configured mcp.servers entry for a data-sharing agreement and supply-chain risk assessment. Remove servers that are no longer needed."
     },
     {
-      "id": "SC-28",
-      "family": "SC",
-      "name": "Protection of Information at Rest",
-      "status": "full",
-      "openclaw_settings": [
-        "memory.encryption",
-        "secrets.providers",
-        "logging.redactSensitive",
-        "diagnostics.otel.captureContent.enabled",
-        "diagnostics.cacheTrace.enabled",
-        "env",
-        "media.preserveFilenames",
-        "media.ttlHours"
-      ],
-      "os_checks": [
-        "stat ~/.openclaw/secrets/",
-        "ls -la ~/.openclaw/"
-      ],
-      "remediation": "Secrets directory must be 700. All secret files must be 600. Owner must be service account only."
-    },
-    {
-      "id": "SI-2",
-      "family": "SI",
-      "name": "Flaw Remediation",
+      "id": "SA-22",
+      "family": "SA",
+      "name": "Unsupported System Components",
       "status": "partial",
       "openclaw_settings": [],
       "os_checks": [
-        "apt list --upgradable",
-        "unattended-upgrades --dry-run"
+        "cat /etc/os-release",
+        "node --version"
       ],
-      "remediation": "Enable unattended-upgrades for security patches. Review and apply pending updates."
+      "remediation": "Upgrade Ubuntu and Node.js before their end-of-life dates. Track EOL schedules at https://endoflife.date/ubuntu and https://endoflife.date/nodejs."
     },
     {
-      "id": "AC-4",
-      "family": "AC",
-      "name": "Information Flow Enforcement",
+      "id": "SC-2",
+      "family": "SC",
+      "name": "Application Partitioning",
       "status": "full",
-      "openclaw_settings": [
-        "session.dmScope",
-        "messages.groupChat.visibleReplies",
-        "tools.web.search.enabled",
-        "tools.web.fetch.enabled",
-        "diagnostics.otel.captureContent.enabled",
-        "broadcast.strategy",
-        "acp.stream.maxOutputChars",
-        "surfaces.*.silentReply"
-      ],
-      "os_checks": [],
-      "remediation": "Set session.dmScope to per-channel-peer. Review tools.web settings. Disable diagnostics.otel.captureContent unless the collector is within your data boundary."
-    },
-    {
-      "id": "AC-7",
-      "family": "AC",
-      "name": "Unsuccessful Logon Attempts",
-      "status": "full",
-      "openclaw_settings": [
-        "gateway.auth.rateLimit.maxAttempts",
-        "gateway.auth.rateLimit.windowMs",
-        "gateway.auth.rateLimit.lockoutMs",
-        "auth.cooldowns"
-      ],
+      "openclaw_settings": [],
       "os_checks": [
-        "pam_faillock status"
+        "ps aux",
+        "readlink /proc/PID/ns/mnt"
       ],
-      "remediation": "Configure gateway.auth.rateLimit with maxAttempts=10, windowMs=60000, lockoutMs=300000. Configure PAM faillock."
+      "remediation": "Run OpenClaw under a dedicated non-root service account. Consider container or namespace isolation."
     },
     {
-      "id": "AC-12",
-      "family": "AC",
-      "name": "Session Termination",
+      "id": "SC-4",
+      "family": "SC",
+      "name": "Information in Shared Resources",
       "status": "full",
-      "openclaw_settings": [
-        "mcp.sessionIdleTtlMs",
-        "agents.defaults.subagents.archiveAfterMinutes",
-        "cron.sessionRetention",
-        "acp.runtime.ttlMinutes",
-        "crestodian.rescue.pendingTtlMinutes"
+      "openclaw_settings": [],
+      "os_checks": [
+        "find /tmp -name *openclaw*",
+        "ls /dev/shm"
       ],
-      "os_checks": [],
-      "remediation": "Set mcp.sessionIdleTtlMs to 600000 (10 min). Set subagents.archiveAfterMinutes to 60. Review cron.sessionRetention."
-    },
-    {
-      "id": "CM-3",
-      "family": "CM",
-      "name": "Configuration Change Control",
-      "status": "full",
-      "openclaw_settings": [
-        "gateway.reload.mode",
-        "update.auto.enabled",
-        "commands.restart"
-      ],
-      "os_checks": [],
-      "remediation": "Set gateway.reload.mode to hybrid. Disable update.auto unless stableDelayHours >= 6. Review restart command availability."
-    },
-    {
-      "id": "CM-5",
-      "family": "CM",
-      "name": "Access Restrictions for Change",
-      "status": "full",
-      "openclaw_settings": [
-        "skills.workshop.approvalPolicy",
-        "skills.install.allowUploadedArchives",
-        "skills.workshop.allowSymlinkTargetWrites",
-        "plugins.entries"
-      ],
-      "os_checks": [],
-      "remediation": "Set skills.workshop.approvalPolicy to review. Disable allowUploadedArchives and allowSymlinkTargetWrites. Review plugin entries for hooks.allowPromptInjection."
+      "remediation": "Configure periodic cleanup of /tmp session data. Review /dev/shm for sensitive residue."
     },
     {
       "id": "SC-5",
@@ -447,251 +776,20 @@
       "remediation": "Set browser.ssrfPolicy.dangerouslyAllowPrivateNetwork=false. Set discovery.mdns.mode=minimal. Disable external hooks unless required."
     },
     {
-      "id": "SI-4",
-      "family": "SI",
-      "name": "Information System Monitoring",
+      "id": "SC-8",
+      "family": "SC",
+      "name": "Transmission Confidentiality and Integrity",
       "status": "full",
       "openclaw_settings": [
-        "diagnostics.enabled",
-        "audit.enabled",
-        "cron.failureAlert.enabled",
-        "security.audit.suppressions"
-      ],
-      "os_checks": [
-        "systemctl status auditd"
-      ],
-      "remediation": "Enable diagnostics, audit, and cron.failureAlert. Enable auditd on the host. Review security.audit.suppressions for blind spots."
-    },
-    {
-      "id": "CP-10",
-      "family": "CP",
-      "name": "System Recovery and Reconstitution",
-      "status": "full",
-      "openclaw_settings": [
-        "crestodian.rescue.enabled",
-        "crestodian.rescue.ownerDmOnly",
-        "crestodian.rescue.pendingTtlMinutes"
-      ],
-      "os_checks": [],
-      "remediation": "If rescue mode is enabled, restrict to ownerDmOnly=true. Set pendingTtlMinutes to a short window (5 min default) to prevent stale rescue state."
-    },
-    {
-      "id": "CA-7",
-      "family": "CA",
-      "name": "Continuous Monitoring",
-      "status": "full",
-      "openclaw_settings": [
-        "security.installPolicy.enabled",
-        "security.audit.suppressions",
-        "diagnostics.enabled"
-      ],
-      "os_checks": [
-        "systemctl status auditd",
-        "unattended-upgrades --dry-run"
-      ],
-      "remediation": "Enable security.installPolicy. Review audit suppressions. Enable diagnostics."
-    },
-    {
-      "id": "SI-17",
-      "family": "SI",
-      "name": "Fail-Safe Procedures",
-      "status": "full",
-      "openclaw_settings": [
-        "cron.retry.maxAttempts",
-        "crestodian.rescue.enabled",
-        "crestodian.rescue.pendingTtlMinutes"
-      ],
-      "os_checks": [],
-      "remediation": "Bound cron retry.maxAttempts. If crestodian rescue is enabled, set short pendingTtlMinutes."
-    },
-    {
-      "id": "SI-12",
-      "family": "SI",
-      "name": "Information Management and Retention",
-      "status": "full",
-      "openclaw_settings": [
-        "agents.defaults.compaction.mode",
-        "agents.defaults.compaction.memoryFlush.enabled",
-        "agents.defaults.compaction.truncateAfterCompaction",
-        "transcripts.enabled",
-        "transcripts.maxUtterances",
-        "media.ttlHours"
-      ],
-      "os_checks": [],
-      "remediation": "Set compaction.mode to safeguard. Enable memoryFlush and truncateAfterCompaction. Review transcripts.maxUtterances and media.ttlHours retention bounds. Review compaction thresholds on CM-2 baseline cadence."
-    },
-    {
-      "id": "SI-3",
-      "family": "SI",
-      "name": "Malicious Code Protection",
-      "status": "partial",
-      "openclaw_settings": [],
-      "os_checks": [
-        "which clamav",
-        "systemctl status clamav-daemon"
-      ],
-      "remediation": "Install and configure ClamAV or equivalent. Schedule regular scans."
-    },
-    {
-      "id": "AU-4",
-      "family": "AU",
-      "name": "Audit Log Storage Capacity",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "df -P /var/log/audit",
-        "df -P /var/log"
-      ],
-      "remediation": "Ensure the audit log partition retains at least 10% free space. Configure log rotation with adequate headroom or expand storage."
-    },
-    {
-      "id": "AU-5",
-      "family": "AU",
-      "name": "Response to Audit Processing Failures",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "grep disk_full_action /etc/audit/auditd.conf",
-        "grep admin_space_left_action /etc/audit/auditd.conf"
-      ],
-      "remediation": "Set disk_full_action and admin_space_left_action in auditd.conf to something other than IGNORE (e.g. SYSLOG, EMAIL, HALT)."
-    },
-    {
-      "id": "AU-7",
-      "family": "AU",
-      "name": "Audit Record Reduction and Report Generation",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "which journalctl",
-        "which ausearch",
-        "grep -r '@' /etc/rsyslog.d/"
-      ],
-      "remediation": "Install auditd (provides ausearch) or configure rsyslog forwarding so audit records can be queried and aggregated."
-    },
-    {
-      "id": "AU-8",
-      "family": "AU",
-      "name": "Time Stamps",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "timedatectl show -p NTPSynchronized",
-        "chronyc tracking"
-      ],
-      "remediation": "Enable NTP synchronization: sudo timedatectl set-ntp true."
-    },
-    {
-      "id": "AU-11",
-      "family": "AU",
-      "name": "Audit Record Retention",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "grep rotate /etc/logrotate.d/auditd"
-      ],
-      "remediation": "Configure logrotate for audit logs with a 'rotate' count of at least 4 (weekly rotation) to meet minimum retention."
-    },
-    {
-      "id": "CA-9",
-      "family": "CA",
-      "name": "Internal System Connections",
-      "status": "partial",
-      "openclaw_settings": [
+        "gateway.tls.enabled",
+        "gateway.controlUi.allowInsecureAuth",
         "mcp.servers"
       ],
       "os_checks": [
-        "parse ~/.openclaw/openclaw.json mcp.servers"
+        "ss -tlnp",
+        "openssl s_client -connect localhost:18790"
       ],
-      "remediation": "Document each MCP server connection in the system security plan / interconnection agreements. Remove any unused or unauthorized servers."
-    },
-    {
-      "id": "CP-9",
-      "family": "CP",
-      "name": "System Backup",
-      "status": "partial",
-      "openclaw_settings": [],
-      "os_checks": [
-        "crontab -l | grep -i backup",
-        "systemctl list-timers --all | grep -i backup"
-      ],
-      "remediation": "Configure a scheduled backup (cron or systemd timer) of ~/.openclaw config, secrets, and workspace state. Verify backups are recoverable."
-    },
-    {
-      "id": "IA-4",
-      "family": "IA",
-      "name": "Identifier Management",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "awk -F: '{print $3}' /etc/passwd | sort | uniq -d"
-      ],
-      "remediation": "Eliminate duplicate UIDs in /etc/passwd. Never reuse a UID after deleting an account."
-    },
-    {
-      "id": "IA-7",
-      "family": "IA",
-      "name": "Cryptographic Module Authentication",
-      "status": "full",
-      "openclaw_settings": [
-        "gateway.tls"
-      ],
-      "os_checks": [
-        "grep Protocol /etc/ssh/sshd_config",
-        "grep Ciphers /etc/ssh/sshd_config"
-      ],
-      "remediation": "Disable SSHv1 and weak ciphers (3DES, RC4/arcfour, CBC-mode) in sshd_config. Set gateway TLS minVersion to TLSv1.2 or higher."
-    },
-    {
-      "id": "IA-8",
-      "family": "IA",
-      "name": "Identification and Authentication (Non-Org Users)",
-      "status": "full",
-      "openclaw_settings": [
-        "auth.mode",
-        "auth.providers"
-      ],
-      "os_checks": [
-        "grep -o auth.mode/providers in openclaw.json"
-      ],
-      "remediation": "Set an explicit auth.mode and register auth.providers. Disable anonymous access so external channel users (Discord/Telegram/etc.) are identified before gateway trust."
-    },
-    {
-      "id": "IA-11",
-      "family": "IA",
-      "name": "Re-authentication",
-      "status": "full",
-      "openclaw_settings": [
-        "mcp.sessionIdleTtlMs"
-      ],
-      "os_checks": [
-        "grep sessionIdleTtlMs in openclaw.json"
-      ],
-      "remediation": "Set mcp.sessionIdleTtlMs to a finite, reasonable value (e.g. 24h or less) so idle sessions require re-authentication."
-    },
-    {
-      "id": "SC-2",
-      "family": "SC",
-      "name": "Application Partitioning",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "ps aux",
-        "readlink /proc/PID/ns/mnt"
-      ],
-      "remediation": "Run OpenClaw under a dedicated non-root service account. Consider container or namespace isolation."
-    },
-    {
-      "id": "SC-4",
-      "family": "SC",
-      "name": "Information in Shared Resources",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "find /tmp -name *openclaw*",
-        "ls /dev/shm"
-      ],
-      "remediation": "Configure periodic cleanup of /tmp session data. Review /dev/shm for sensitive residue."
+      "remediation": "Enable TLS on gateway. Use Cloudflare Tunnel (TLS enforced) for all remote access."
     },
     {
       "id": "SC-12",
@@ -745,6 +843,27 @@
       "remediation": "Set auth.enabled: true and configure a strong gatewayToken in openclaw.json."
     },
     {
+      "id": "SC-28",
+      "family": "SC",
+      "name": "Protection of Information at Rest",
+      "status": "full",
+      "openclaw_settings": [
+        "memory.encryption",
+        "secrets.providers",
+        "logging.redactSensitive",
+        "diagnostics.otel.captureContent.enabled",
+        "diagnostics.cacheTrace.enabled",
+        "env",
+        "media.preserveFilenames",
+        "media.ttlHours"
+      ],
+      "os_checks": [
+        "stat ~/.openclaw/secrets/",
+        "ls -la ~/.openclaw/"
+      ],
+      "remediation": "Secrets directory must be 700. All secret files must be 600. Owner must be service account only."
+    },
+    {
       "id": "SC-39",
       "family": "SC",
       "name": "Process Isolation",
@@ -755,6 +874,46 @@
         "readlink /proc/PID/ns/{pid,net,mnt}"
       ],
       "remediation": "Run OpenClaw in a container or systemd slice with resource limits. Use network and PID namespaces to isolate the agent."
+    },
+    {
+      "id": "SI-2",
+      "family": "SI",
+      "name": "Flaw Remediation",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": [
+        "apt list --upgradable",
+        "unattended-upgrades --dry-run"
+      ],
+      "remediation": "Enable unattended-upgrades for security patches. Review and apply pending updates."
+    },
+    {
+      "id": "SI-3",
+      "family": "SI",
+      "name": "Malicious Code Protection",
+      "status": "partial",
+      "openclaw_settings": [],
+      "os_checks": [
+        "which clamav",
+        "systemctl status clamav-daemon"
+      ],
+      "remediation": "Install and configure ClamAV or equivalent. Schedule regular scans."
+    },
+    {
+      "id": "SI-4",
+      "family": "SI",
+      "name": "Information System Monitoring",
+      "status": "full",
+      "openclaw_settings": [
+        "diagnostics.enabled",
+        "audit.enabled",
+        "cron.failureAlert.enabled",
+        "security.audit.suppressions"
+      ],
+      "os_checks": [
+        "systemctl status auditd"
+      ],
+      "remediation": "Enable diagnostics, audit, and cron.failureAlert. Enable auditd on the host. Review security.audit.suppressions for blind spots."
     },
     {
       "id": "SI-7",
@@ -769,6 +928,22 @@
       "remediation": "Ensure APT::Get::AllowUnauthenticated is unset or false. Verify apt repository GPG keys are configured under /etc/apt/trusted.gpg.d/."
     },
     {
+      "id": "SI-12",
+      "family": "SI",
+      "name": "Information Management and Retention",
+      "status": "full",
+      "openclaw_settings": [
+        "agents.defaults.compaction.mode",
+        "agents.defaults.compaction.memoryFlush.enabled",
+        "agents.defaults.compaction.truncateAfterCompaction",
+        "transcripts.enabled",
+        "transcripts.maxUtterances",
+        "media.ttlHours"
+      ],
+      "os_checks": [],
+      "remediation": "Set compaction.mode to safeguard. Enable memoryFlush and truncateAfterCompaction. Review transcripts.maxUtterances and media.ttlHours retention bounds. Review compaction thresholds on CM-2 baseline cadence."
+    },
+    {
       "id": "SI-16",
       "family": "SI",
       "name": "Memory Protection",
@@ -780,39 +955,17 @@
       "remediation": "Set kernel.randomize_va_space=2 for full ASLR: sudo sysctl -w kernel.randomize_va_space=2."
     },
     {
-      "id": "SA-9",
-      "family": "SA",
-      "name": "External System Services",
-      "status": "partial",
+      "id": "SI-17",
+      "family": "SI",
+      "name": "Fail-Safe Procedures",
+      "status": "full",
       "openclaw_settings": [
-        "mcp.servers"
+        "cron.retry.maxAttempts",
+        "crestodian.rescue.enabled",
+        "crestodian.rescue.pendingTtlMinutes"
       ],
       "os_checks": [],
-      "remediation": "Review each configured mcp.servers entry for a data-sharing agreement and supply-chain risk assessment. Remove servers that are no longer needed."
-    },
-    {
-      "id": "SA-22",
-      "family": "SA",
-      "name": "Unsupported System Components",
-      "status": "partial",
-      "openclaw_settings": [],
-      "os_checks": [
-        "cat /etc/os-release",
-        "node --version"
-      ],
-      "remediation": "Upgrade Ubuntu and Node.js before their end-of-life dates. Track EOL schedules at https://endoflife.date/ubuntu and https://endoflife.date/nodejs."
-    },
-    {
-      "id": "MP-6",
-      "family": "MP",
-      "name": "Media Sanitization",
-      "status": "partial",
-      "openclaw_settings": [
-        "media.ttlHours",
-        "media.maxSizeMb"
-      ],
-      "os_checks": [],
-      "remediation": "Set media.ttlHours to a positive retention window and media.maxSizeMb to bound stored media size in the OpenClaw config."
+      "remediation": "Bound cron retry.maxAttempts. If crestodian rescue is enabled, set short pendingTtlMinutes."
     },
     {
       "id": "SR-11",
@@ -825,100 +978,6 @@
         "ls /etc/apt/trusted.gpg.d/"
       ],
       "remediation": "Add source/author/origin metadata to installed skills. Verify APT package signing keys are present under /etc/apt/trusted.gpg.d/."
-    },
-    {
-      "id": "AC-5",
-      "family": "AC",
-      "name": "Separation of Duties",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "whoami",
-        "groups <user>"
-      ],
-      "remediation": "Run OpenClaw under a dedicated service account that is not a member of the sudo/admin group."
-    },
-    {
-      "id": "AC-8",
-      "family": "AC",
-      "name": "System Use Notification",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "grep ^Banner /etc/ssh/sshd_config"
-      ],
-      "remediation": "Set a Banner directive in sshd_config pointing to a system-use notification file."
-    },
-    {
-      "id": "AC-10",
-      "family": "AC",
-      "name": "Concurrent Session Control",
-      "status": "partial",
-      "openclaw_settings": [],
-      "os_checks": [
-        "grep maxlogins /etc/security/limits.conf"
-      ],
-      "remediation": "Set a maxlogins limit in /etc/security/limits.conf to bound concurrent sessions per user."
-    },
-    {
-      "id": "AC-11",
-      "family": "AC",
-      "name": "Device Lock",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "grep TMOUT /etc/profile /etc/profile.d/*"
-      ],
-      "remediation": "Set TMOUT in /etc/profile or /etc/profile.d/ to auto-lock idle shell sessions."
-    },
-    {
-      "id": "AC-14",
-      "family": "AC",
-      "name": "Permitted Actions Without Identification or Authentication",
-      "status": "full",
-      "openclaw_settings": [
-        "auth.enabled"
-      ],
-      "os_checks": [],
-      "remediation": "Set auth.enabled to true in openclaw.json so gateway actions require identification/authentication."
-    },
-    {
-      "id": "CM-8",
-      "family": "CM",
-      "name": "System Component Inventory",
-      "status": "full",
-      "openclaw_settings": [
-        "mcp.servers",
-        "plugins.entries"
-      ],
-      "os_checks": [
-        "node --version"
-      ],
-      "remediation": "Maintain an approved component list and reconcile it against the reported Node.js version, MCP servers, and plugins."
-    },
-    {
-      "id": "CM-11",
-      "family": "CM",
-      "name": "User-Installed Software",
-      "status": "partial",
-      "openclaw_settings": [],
-      "os_checks": [
-        "npm list -g --depth=0"
-      ],
-      "remediation": "Review globally-installed npm packages and remove any that are not approved for the host."
-    },
-    {
-      "id": "RA-5",
-      "family": "RA",
-      "name": "Vulnerability Monitoring and Scanning",
-      "status": "full",
-      "openclaw_settings": [],
-      "os_checks": [
-        "trivy/grype/oscap/lynis/debsecan",
-        "npm audit",
-        "apt list --upgradable"
-      ],
-      "remediation": "Install a vulnerability scanner (trivy or grype recommended). Run npm audit on OpenClaw dependencies. Apply pending OS security patches."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Phase 2 AC/CM controls**: 12 new NIST 800-53 checks for Access Control (AC) and Configuration Management (CM) families, with updated findings catalog and controls baseline
- **Restored CI/release workflows**: `ci.yml` and `release.yml` were added in c113469 but lost in a subsequent commit on main. Extracted from that commit and restored to `.github/workflows/`
- CI workflow runs all 4 integration test suites on push/PR to main; release workflow triggers on `v*` tags and auto-generates changelogs

## Test plan

All 4 integration test suites pass locally:
- [x] report-validation: 12/12
- [x] catalog-platform-field: 5/5
- [x] drift-detection: 14/14
- [x] agent-safety-checks: 19/19

Once merged, CI workflows will self-validate on subsequent pushes.

Generated with [Claude Code](https://claude.com/claude-code)